### PR TITLE
Fix #195 and #196, add inf(Sign,Precision) for FloatXX

### DIFF
--- a/python/numeric_submodule.cpp
+++ b/python/numeric_submodule.cpp
@@ -97,15 +97,26 @@ template<class A> auto _is_inf_(A const& a) -> Bool { return is_inf(a); }
 template<class A> auto _is_finite_(A const& a) -> Bool { return is_finite(a); }
 template<class A> auto _is_zero_(A const& a) -> Bool { return is_zero(a); }
 
-template<class X> Void define_infinitary(pybind11::module& module, pybind11::class_<X>& pyclass) {
-    pyclass.def_static("nan", (X(*)()) &X::nan);
-    pyclass.def_static("inf", (X(*)()) &X::inf);
-    pyclass.def_static("inf", (X(*)(Sign)) &X::inf);
-
+template<class X> Void define_infinitary_checks(pybind11::module& module, pybind11::class_<X>& pyclass) {
     module.def("is_nan", &_is_nan_<X>);
     module.def("is_inf", &_is_inf_<X>);
     module.def("is_finite", &_is_finite_<X>);
     module.def("is_zero", &_is_zero_<X>);
+}
+
+template<class X,EnableIf<Not<Or<IsSame<X,FloatDP>,IsSame<X,FloatMP>>>> =dummy> Void define_infinitary(pybind11::module& module, pybind11::class_<X>& pyclass) {
+    pyclass.def_static("nan", (X(*)()) &X::nan);
+    pyclass.def_static("inf", (X(*)()) &X::inf);
+    pyclass.def_static("inf", (X(*)(Sign)) &X::inf);
+
+    define_infinitary_checks(module,pyclass);
+}
+template<class X,EnableIf<Or<IsSame<X,FloatDP>,IsSame<X,FloatMP>>> =dummy> Void define_infinitary(pybind11::module& module, pybind11::class_<X>& pyclass) {
+    pyclass.def_static("nan", (X(*)(typename X::PrecisionType)) &X::nan);
+    pyclass.def_static("inf", (X(*)(typename X::PrecisionType)) &X::inf);
+    pyclass.def_static("inf", (X(*)(Sign,typename X::PrecisionType)) &X::inf);
+
+    define_infinitary_checks(module,pyclass);
 }
 
 } // namespace Ariadne

--- a/source/function/taylor_model.tpl.hpp
+++ b/source/function/taylor_model.tpl.hpp
@@ -419,7 +419,7 @@ template<class F> Void _scal(TaylorModel<ValidatedTag,F>& r, const Bounds<F>& c)
     ARIADNE_ASSERT_MSG(is_finite(c.lower().raw()) && is_finite(c.upper().raw()),"scal(tm,c): tm="<<r<<", c="<<c);
     ARIADNE_DEBUG_ASSERT(r.error().raw()>=0);
 
-    const F inf = F::inf();
+    const F inf = F::inf(r.precision());
     if(r.error().raw()==inf) {
         r.expansion().clear(); return;
     }
@@ -476,7 +476,7 @@ template<class F> inline Void _acc(TaylorModel<ValidatedTag,F>& r, const Bounds<
     ARIADNE_DEBUG_ASSERT_MSG(r.error().raw()>=0,r);
     typedef typename F::PrecisionType PR;
 
-    const F inf = F::inf();
+    const F inf = F::inf(r.precision());
     if(c.lower().raw()==-inf || c.upper().raw()==+inf) {
         r.clear();
         r.set_error(mag(FloatValue<PR>(inf)));

--- a/source/numeric/float-user.cpp
+++ b/source/numeric/float-user.cpp
@@ -55,7 +55,7 @@ template<class F> Nat Approximation<F>::output_places = 4;
 template<class F> Nat Bounds<F>::output_places=8;
 template<class F> Nat Value<F>::output_places = 16;
 
-const FloatDPValue infty = FloatDPValue(FloatDP::inf());
+const FloatDPValue infty = FloatDPValue(FloatDP::inf(dp));
 
 OutputStream& operator<<(OutputStream& os, Rounding const& rnd) {
     return os << ( rnd._rbp == ROUND_TO_NEAREST ? "near" : (rnd._rbp == ROUND_DOWNWARD ? "down" : "up") ); }
@@ -871,7 +871,7 @@ template<class F> struct Operations<Bounds<F>> {
         if(x._l>0 || x._u<0) {
             return Bounds<F>(rec(down,x._u),rec(up,x._l));
         } else {
-            F inf_=F::inf();
+            F inf_=F::inf(x.precision());
             //ARIADNE_THROW(DivideByZeroException,"FloatBounds rec(FloatBounds x)","x="<<x);
             return Bounds<F>(-inf_,+inf_);
         }
@@ -945,8 +945,9 @@ template<class F> struct Operations<Bounds<F>> {
         }
         else {
             //ARIADNE_THROW(DivideByZeroException,"FloatBounds div(FloatBounds x1, FloatBounds x2)","x1="<<x1<<", x2="<<x2);
-            rl=-F::inf();
-            ru=+F::inf();
+            PR pr=max(x1.precision(),x2.precision());
+            rl=-F::inf(pr);
+            ru=+F::inf(pr);
         }
         return Bounds<F>(rl,ru);
     }

--- a/source/numeric/floatdp.cpp
+++ b/source/numeric/floatdp.cpp
@@ -725,15 +725,16 @@ Void FloatDP::set_precision(FloatDP::PrecisionType) { }
 FloatDP FloatDP::min(PrecisionType) { return std::numeric_limits<double>::min(); }
 FloatDP FloatDP::max(PrecisionType) { return std::numeric_limits<double>::max(); }
 FloatDP FloatDP::eps(PrecisionType) { return std::numeric_limits<double>::epsilon(); }
-FloatDP FloatDP::nan() { return std::numeric_limits<double>::quiet_NaN(); }
-FloatDP FloatDP::inf() { return std::numeric_limits<double>::infinity(); }
-FloatDP FloatDP::inf(Sign sgn) {
+
+FloatDP FloatDP::inf(Sign sgn, PrecisionType pr) {
     switch (sgn) {
     case Sign::POSITIVE: return std::numeric_limits<double>::infinity();
     case Sign::NEGATIVE: return -std::numeric_limits<double>::infinity();
     default: return std::numeric_limits<double>::quiet_NaN();
     }
 }
+FloatDP FloatDP::inf(PrecisionType pr) { return FloatDP::inf(Sign::POSITIVE,pr); }
+FloatDP FloatDP::nan(PrecisionType pr) { return FloatDP::inf(Sign::ZERO,pr); }
 
 template<class R, class A> R integer_cast(A const&);
 template<> Nat integer_cast<Nat,FloatDP>(FloatDP const& x) { return x.dbl; }

--- a/source/numeric/floatdp.hpp
+++ b/source/numeric/floatdp.hpp
@@ -137,9 +137,11 @@ class FloatDP {
     DoublePrecision precision() const;
     Void set_precision(DoublePrecision);
   public:
-    static FloatDP nan();
-    static FloatDP inf();
-    static FloatDP inf(Sign sgn);
+
+    static FloatDP nan(DoublePrecision pr);
+    static FloatDP inf(Sign sgn, DoublePrecision pr);
+    static FloatDP inf(DoublePrecision pr);
+
     static FloatDP max(DoublePrecision pr);
     static FloatDP eps(DoublePrecision pr);
     static FloatDP min(DoublePrecision pr);

--- a/source/numeric/floatmp.cpp
+++ b/source/numeric/floatmp.cpp
@@ -232,20 +232,20 @@ double FloatMP::get_d() const {
     return mpfr_get_d(this->_mpfr,get_rounding_mode());
 }
 
-FloatMP FloatMP::nan() {
-    FloatMP x;
+FloatMP FloatMP::nan(MultiplePrecision pr) {
+    FloatMP x(pr);
     mpfr_set_nan(x._mpfr);
     return x;
 }
 
-FloatMP FloatMP::inf() {
-    FloatMP x;
+FloatMP FloatMP::inf(MultiplePrecision pr) {
+    FloatMP x(pr);
     mpfr_set_inf(x._mpfr,+1);
     return x;
 }
 
-FloatMP FloatMP::inf(Sign sgn) {
-    FloatMP x;
+FloatMP FloatMP::inf(Sign sgn, MultiplePrecision pr) {
+    FloatMP x(pr);
     switch (sgn) {
     case Sign::POSITIVE: mpfr_set_inf(x._mpfr,+1); break;
     case Sign::NEGATIVE: mpfr_set_inf(x._mpfr,-1); break;

--- a/source/numeric/floatmp.hpp
+++ b/source/numeric/floatmp.hpp
@@ -98,9 +98,10 @@ class FloatMP {
     static Void set_default_precision(PrecisionType prec);
     static PrecisionType get_default_precision();
   public:
-    static FloatMP nan();
-    static FloatMP inf();
-    static FloatMP inf(Sign sgn);
+    static FloatMP inf(Sign, PrecisionType);
+    static FloatMP inf(PrecisionType);
+    static FloatMP nan(PrecisionType);
+
     static FloatMP max(PrecisionType);
     static FloatMP eps(PrecisionType);
     static FloatMP min(PrecisionType);

--- a/tests/function/test_taylor_model.cpp
+++ b/tests/function/test_taylor_model.cpp
@@ -324,7 +324,7 @@ template<class F> Void TestTaylorModel<F>::test_arithmetic()
     ARIADNE_TEST_SAME(pow(t,2),t*t);
     ARIADNE_TEST_SAME(pow(t,3),t*t*t);
 
-    F inf_ = F::inf();
+    F inf_ = F::inf(pr);
     ValidatedTaylorModel<F> tm_inf(Expansion<MultiIndex,FloatType>(2),+inf_,swp);
     ValidatedTaylorModel<F> tm_zero_times_inf=0*tm_inf;
     if(is_nan(tm_zero_times_inf.error().raw())) {

--- a/tests/numeric/test_float.cpp
+++ b/tests/numeric/test_float.cpp
@@ -319,11 +319,12 @@ TestFloat<PR>::test_limits()
     Float min=Float::min(precision);
     Float eps=Float::eps(precision);
     Float max=Float::max(precision);
-    Float inf_=Float::inf();
-    Float pinf=Float::inf(Sign::POSITIVE);
-    Float ninf=Float::inf(Sign::NEGATIVE);
-    Float zinf=Float::inf(Sign::ZERO);
-    Float nan=Float::nan();
+
+    Float inf_=Float::inf(precision);
+    Float pinf=Float::inf(Sign::POSITIVE,precision);
+    Float ninf=Float::inf(Sign::NEGATIVE,precision);
+    Float zinf=Float::inf(Sign::ZERO,precision);
+    Float nan=Float::nan(precision);
 
     ARIADNE_TEST_PRINT(eps);
     ARIADNE_TEST_COMPARE(add(down,one,eps),>,one);

--- a/tests/numeric/test_validated_float.cpp
+++ b/tests/numeric/test_validated_float.cpp
@@ -760,7 +760,7 @@ template<class PR> Void TestFloatBounds<PR>::test_trigonometric_functions()
 }
 
 template<class PR> Void TestFloatBounds<PR>::regression_tests() {
-    RawFloatType inf_=RawFloatType::inf();
+    RawFloatType inf_=RawFloatType::inf(precision);
 
     // Regression test; fails dramatically on certain types of rounding
     {


### PR DESCRIPTION
This restores the inf(Precision) methods and adds the inf(Sign,Precision) functionality that was needed. The fix for #195 then just specializes for FloatDP and FloatMP, while refactoring the implementation a bit to avoid code repetition.