### PR TITLE
Bounder functionality

### DIFF
--- a/examples/noisy/noisy-benchmark.cpp
+++ b/examples/noisy/noisy-benchmark.cpp
@@ -32,7 +32,6 @@
 #include "rossler-attractor.hpp"
 #include "jerk16.hpp"
 #include "dc-dc.hpp"
-#include "harmonic-oscillator.hpp"
 
 #include "noisy-utilities.hpp"
 
@@ -41,7 +40,7 @@ using namespace Ariadne;
 
 int main()
 {
-    List<SystemType> systems = {HS(),CR(),LV(),JE(),PI(),J21(),LA(),RA(),J16(),DC(),HO()};
+    List<SystemType> systems = {HS(),CR(),LV(),JE(),PI(),J21(),LA(),RA(),J16(),DC()};
 
     for (SystemType s : systems) {
         std::cout << std::get<0>(s) << std::endl;

--- a/examples/noisy/noisy-utilities.hpp
+++ b/examples/noisy/noisy-utilities.hpp
@@ -29,8 +29,8 @@ namespace Ariadne {
 
 typedef Tuple<String,DottedRealAssignments,RealVariablesBox,RealVariablesBox,Real,double> SystemType;
 
-void run_single(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximation> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity, bool draw);
-void run_each_approximation(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximation> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity, bool draw);
+void run_single(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximationKind> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity, bool draw);
+void run_each_approximation(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximationKind> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity, bool draw);
 void run_noisy_system(String name, const DottedRealAssignments& dynamics, const RealVariablesBox& inputs, const RealVariablesBox& initial, Real evolution_time, double step);
 void run_noisy_system(SystemType system);
 
@@ -53,7 +53,7 @@ template<class C> struct Reverse {
 template<class C> Reverse<C> reverse(C const& c) { return Reverse<C>(c); }
 
 
-void run_single(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximation> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity, bool draw) {
+void run_single(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximationKind> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity, bool draw) {
 
     typedef typename ValidatedVectorFunctionModelType::NumericType NumericType;
     typedef typename NumericType::PrecisionType PrecisionType;
@@ -103,10 +103,10 @@ void run_single(String name, DifferentialInclusionIVP const& ivp, Real evolution
     }
 }
 
-void run_each_approximation(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximation> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity, bool draw) {
+void run_each_approximation(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximationKind> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity, bool draw) {
 
     for (auto appro: approximations) {
-        List<InputApproximation> singleapproximation = {appro};
+        List<InputApproximationKind> singleapproximation = {appro};
         std::cout << appro << std::endl;
         run_single(name,ivp,evolution_time,step,singleapproximation,sweeper,freq,verbosity,draw);
     }
@@ -124,12 +124,12 @@ void run_noisy_system(String name, const DottedRealAssignments& dynamics, const 
     bool draw = false;
     DRAWING_METHOD = DrawingMethod::BOX;
 
-    List<InputApproximation> approximations;
-    approximations.append(InputApproximation::ZERO);
-    approximations.append(InputApproximation::CONSTANT);
-    approximations.append(InputApproximation::AFFINE);
-    approximations.append(InputApproximation::SINUSOIDAL);
-    approximations.append(InputApproximation::PIECEWISE);
+    List<InputApproximationKind> approximations;
+    approximations.append(InputApproximationKind::ZERO);
+    approximations.append(InputApproximationKind::CONSTANT);
+    approximations.append(InputApproximationKind::AFFINE);
+    approximations.append(InputApproximationKind::SINUSOIDAL);
+    approximations.append(InputApproximationKind::PIECEWISE);
 
     run_single(name,ivp,evolution_time,step,approximations,sweeper,freq,verbosity,draw);
     //run_each_approximation(name,ivp,evolution_time,step,approximations,sweeper,freq,verbosity,draw);

--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -786,14 +786,18 @@ class EulerFlowBoundsHandler : public FlowBoundsMethodHandlerBase<FlowBoundsMeth
 class HeunFlowBoundsHandler : public FlowBoundsMethodHandlerBase<FlowBoundsMethod::HEUN> {
   protected:
     virtual UpperBoxType _initial(UpperBoxType wD, BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        UpperBoxType B_end = D + IntervalDomainType(0,h)*apply(f,dom);
-        UpperBoxType BV_end = product(B_end,UpperBoxType(V));
-        return wD + IntervalDomainType(0,h)*(apply(f,dom)+apply(f,BV_end));
+        UpperBoxType k1 = IntervalDomainType(0,h)*apply(f,dom);
+        UpperBoxType B2 = D + k1;
+        UpperBoxType BV2 = product(B2,UpperBoxType(V));
+        UpperBoxType k2 = IntervalDomainType(0,h)*apply(f,BV2);
+        return wD + k1+k2;
     }
     virtual UpperBoxType _refinement(BoxDomainType D, BoxDomainType V, UpperBoxType BV, UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        UpperBoxType B_end = D + IntervalDomainType(0,h)*apply(f,BV);
-        UpperBoxType BV_end = product(B_end,UpperBoxType(V));
-        return D + IntervalDomainType(0,h)/2*(apply(f,BV)+apply(f,BV_end));
+        UpperBoxType k1 = IntervalDomainType(0,h)*apply(f,BV);
+        UpperBoxType B2 = D+k1;
+        UpperBoxType BV2 = product(B2,UpperBoxType(V));
+        UpperBoxType k2 = IntervalDomainType(0,h)*apply(f,BV2);
+        return D + (k1+k2)/2;
     }
   public:
     virtual ~HeunFlowBoundsHandler() = default;

--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -711,22 +711,7 @@ ValidatedVectorFunction build_Fw(ValidatedVectorFunction const& F, Vector<Valida
 
 
 Pair<PositiveFloatDPValue,UpperBoxType> InclusionIntegrator::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
-
-    PositiveFloatDPValue h=cast_exact(hsug);
-
-    RalstonFlowBoundsHandler fbh;
-
-    UpperBoxType B = fbh.initial(f,dom,h);
-
-    while(not refines(fbh.refinement(B,f,dom,h),B)) {
-        h=hlf(h);
-    }
-
-    for(Nat i=0; i<4; ++i) {
-        B = fbh.refinement(B,f,dom,h);
-    }
-
-    return std::make_pair(h,B);
+    return RalstonBounder().flow_bounds(f,dom,hsug);
 }
 
 

--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -711,7 +711,7 @@ ValidatedVectorFunction build_Fw(ValidatedVectorFunction const& F, Vector<Valida
 
 
 Pair<PositiveFloatDPValue,UpperBoxType> InclusionIntegrator::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
-    return EulerBounder().flow_bounds(f,dom,hsug);
+    return EulerBounder().compute(f,dom,hsug);
 }
 
 

--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -745,24 +745,6 @@ compute_flow_function(ValidatedVectorFunction const& dyn, BoxDomainType const& d
         picardPhi=antiderivative(dyn_of_phi,dyn_of_phi.argument_size()-1)+x0f;
     }
 
-    /*
-    TaylorSeriesIntegrator integrator(MaximumError(1e-4),SweepThreshold(1e-8),LipschitzConstant(0.5));
-
-    auto BVh =_approximator->build_flow_domain(cast_exact_box(B), V, h);
-
-    auto seriesPhi = integrator.flow_step(dyn,DVh,h,BVh);
-
-    if (volume(picardPhi.range()) < volume(seriesPhi.range())) {
-        ARIADNE_LOG(2,"Picard flow function chosen\n");
-        return picardPhi;
-
-    } else {
-        ARIADNE_LOG(2,"Series flow function chosen\n");
-        return seriesPhi;
-    }
-    */
-
-
     return picardPhi;
 }
 

--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -55,21 +55,18 @@ inline std::ostream& operator<<(std::ostream& os, const DifferentialInclusionIVP
 
 struct ScheduledApproximator
 {
-    SizeType step;
+    Nat step;
     InputApproximator approximator;
 
-    ScheduledApproximator(SizeType s, InputApproximator a) : step(s), approximator(a) {}
+    ScheduledApproximator(Nat s, InputApproximator a) : step(s), approximator(a) {}
 };
 
 inline OutputStream& operator<<(OutputStream& os, ScheduledApproximator const& sa) {
     return os << "(" << sa.step << ":" << sa.approximator.kind() << ")"; }
 
-struct ScheduledApproximatorComparator
-{
-    inline bool operator() (const ScheduledApproximator& sa1, const ScheduledApproximator& sa2)
-    {
-        return (sa1.step > sa2.step);
-    }
+struct ScheduledApproximatorComparator {
+    inline bool operator() (const ScheduledApproximator& sa1, const ScheduledApproximator& sa2) {
+        return (sa1.step > sa2.step); }
 };
 
 inline char activity_symbol(SizeType step) {
@@ -400,17 +397,14 @@ List<ValidatedVectorFunctionModelDP> InclusionIntegrator::flow(DifferentialInclu
     auto t=PositiveFloatDPValue(0.0);
 
     Map<InputApproximationKind,SizeType> approximation_global_frequencies, approximation_local_frequencies;
+    Map<InputApproximationKind,Nat> delays;
     for (auto appro: _approximations) {
         approximation_global_frequencies[appro] = 0;
         approximation_local_frequencies[appro] = 0;
+        delays[appro] = 0;
     }
 
-    List<ValidatedVectorFunctionModelDP> result;
-
-    SizeType step = 0;
-
     List<ScheduledApproximator> schedule;
-    Map<InputApproximationKind,Nat> delays;
 
     List<InputApproximator> approximations;
     InputApproximatorFactory factory;
@@ -418,10 +412,11 @@ List<ValidatedVectorFunctionModelDP> InclusionIntegrator::flow(DifferentialInclu
         approximations.append(factory.create(di,appro,_sweeper));
 
     for (auto appro: approximations) {
-        schedule.push_back(ScheduledApproximator(SizeType(step),appro));
-        delays[appro.kind()] = 0;
+        schedule.push_back(ScheduledApproximator(0u,appro));
     }
 
+    List<ValidatedVectorFunctionModelDP> result;
+    Nat step = 0u;
     while (possibly(t<FloatDPBounds(tmax,pr))) {
 
         if (verbosity == 1)

--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -711,7 +711,7 @@ ValidatedVectorFunction build_Fw(ValidatedVectorFunction const& F, Vector<Valida
 
 
 Pair<PositiveFloatDPValue,UpperBoxType> InclusionIntegrator::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
-    return RalstonBounder().flow_bounds(f,dom,hsug);
+    return EulerBounder().flow_bounds(f,dom,hsug);
 }
 
 

--- a/source/dynamics/differential_inclusion.hpp
+++ b/source/dynamics/differential_inclusion.hpp
@@ -102,6 +102,7 @@ template<class F> PositiveBounds<F> dexp(Bounds<F> const& x) {
     return PositiveBounds<F>(dexp(x.lower()),dexp(x.upper()));
 }
 
+
 class DifferentialInclusion {
 private:
     DottedRealAssignments _dynamics;

--- a/source/dynamics/differential_inclusion.hpp
+++ b/source/dynamics/differential_inclusion.hpp
@@ -191,30 +191,15 @@ inline std::ostream& operator << (std::ostream& os, const InputApproximationKind
     return os;
 }
 
-class ParametricInputApproximation {
-protected:
-    ParametricInputApproximation(InputApproximationKind kind) : _kind(kind) { }
-public:
-    InputApproximationKind kind() { return _kind; }
-private:
-    InputApproximationKind _kind;
+template<InputApproximationKind A> struct InputApproximationKindTrait {
+    static InputApproximationKind kind() { return A; }
 };
 
-class ZeroApproximation : public ParametricInputApproximation {
-public: ZeroApproximation() : ParametricInputApproximation(InputApproximationKind::ZERO) { }
-};
-class ConstantApproximation : public ParametricInputApproximation {
-public: ConstantApproximation() : ParametricInputApproximation(InputApproximationKind::CONSTANT) { }
-};
-class AffineApproximation : public ParametricInputApproximation {
-public: AffineApproximation() : ParametricInputApproximation(InputApproximationKind::AFFINE) { }
-};
-class SinusoidalApproximation : public ParametricInputApproximation {
-public: SinusoidalApproximation() : ParametricInputApproximation(InputApproximationKind::SINUSOIDAL) { }
-};
-class PiecewiseApproximation : public ParametricInputApproximation {
-public: PiecewiseApproximation() : ParametricInputApproximation(InputApproximationKind::PIECEWISE) { }
-};
+class ZeroApproximation : public InputApproximationKindTrait<InputApproximationKind::ZERO> { };
+class ConstantApproximation : public InputApproximationKindTrait<InputApproximationKind::CONSTANT> { };
+class AffineApproximation : public InputApproximationKindTrait<InputApproximationKind::AFFINE> { };
+class SinusoidalApproximation : public InputApproximationKindTrait<InputApproximationKind::SINUSOIDAL> { };
+class PiecewiseApproximation : public InputApproximationKindTrait<InputApproximationKind::PIECEWISE> { };
 
 template<class A> ErrorType r_value();
 template<> ErrorType r_value<ZeroApproximation>() { return ErrorType(0u); }
@@ -222,13 +207,6 @@ template<> ErrorType r_value<ConstantApproximation>() { return ErrorType(1u); }
 template<> ErrorType r_value<AffineApproximation>() { return ErrorType(5.0/3u); }
 template<> ErrorType r_value<SinusoidalApproximation>() { return ErrorType(5.0/4u); }
 template<> ErrorType r_value<PiecewiseApproximation>() { return ErrorType(1.3645_upper); }
-
-template<class A> constexpr InputApproximationKind approximation_kind();
-template<> constexpr InputApproximationKind approximation_kind<ZeroApproximation>() { return InputApproximationKind::ZERO; }
-template<> constexpr InputApproximationKind approximation_kind<ConstantApproximation>() { return InputApproximationKind::CONSTANT; }
-template<> constexpr InputApproximationKind approximation_kind<AffineApproximation>() { return InputApproximationKind::AFFINE; }
-template<> constexpr InputApproximationKind approximation_kind<SinusoidalApproximation>() { return InputApproximationKind::SINUSOIDAL; }
-template<> constexpr InputApproximationKind approximation_kind<PiecewiseApproximation>() { return InputApproximationKind::PIECEWISE; }
 
 template<class A> constexpr Nat num_params_per_input();
 template<> constexpr Nat num_params_per_input<ZeroApproximation>() { return 0u; }
@@ -357,7 +335,7 @@ class InputApproximatorBase : public InputApproximatorInterface {
     SweeperDP _sweeper;
     SharedPointer<ApproximationErrorProcessorInterface<A>> _processor;
     InputApproximatorBase(DifferentialInclusion const& di, SweeperDP const& sweeper) :
-        _di(di), _sweeper(sweeper), _processor(ApproximationErrorProcessorFactory<A>().create(di)), _kind(approximation_kind<A>()), _num_params_per_input(num_params_per_input<A>()) { }
+        _di(di), _sweeper(sweeper), _processor(ApproximationErrorProcessorFactory<A>().create(di)), _kind(A::kind()), _num_params_per_input(num_params_per_input<A>()) { }
   private:
     const InputApproximationKind _kind;
     const Nat _num_params_per_input;

--- a/source/dynamics/differential_inclusion.hpp
+++ b/source/dynamics/differential_inclusion.hpp
@@ -424,6 +424,8 @@ class InclusionIntegrator : public virtual InclusionIntegratorInterface, public 
     ValidatedVectorFunctionModelDP evaluate_evolve_function(ValidatedVectorFunctionModelDP reach_function, PositiveFloatDPValue t) const;
     ValidatedVectorFunctionModelDP build_secondhalf_piecewise_reach_function(ValidatedVectorFunctionModelDP evolve_function, ValidatedVectorFunctionModelDP Phi, SizeType m, PositiveFloatDPValue t, PositiveFloatDPValue new_t) const;
     Vector<ValidatedScalarFunction> build_secondhalf_piecewise_w_functions(BoxDomainType DVh, SizeType n, SizeType m) const;
+  private:
+    Bool must_recondition(Nat step) const;
 };
 
 template<class... AS> InclusionIntegrator::InclusionIntegrator(List<InputApproximationKind> approximations, SweeperDP sweeper, StepSize step_size_, AS... attributes)

--- a/source/dynamics/differential_inclusion.hpp
+++ b/source/dynamics/differential_inclusion.hpp
@@ -215,32 +215,21 @@ template<> constexpr Nat num_params_per_input<AffineApproximation>() { return 2u
 template<> constexpr Nat num_params_per_input<SinusoidalApproximation>() { return 2u; }
 template<> constexpr Nat num_params_per_input<PiecewiseApproximation>() { return 2u; }
 
-enum class InputsRoles : std::uint8_t { AFFINE, SINGULAR, ADDITIVE};
+enum class InputsRelationKind : std::uint8_t { AFFINE, SINGULAR, ADDITIVE};
 
-class InputsRole {
-protected:
-    InputsRole(InputsRoles kind) : _kind(kind) { }
-public:
-    InputsRoles kind() { return _kind; }
-private:
-    InputsRoles _kind;
+template<InputsRelationKind R> struct InputsRelationKindTrait {
+    static InputsRelationKind kind() { return R; }
 };
 
-class AffineInputs : public InputsRole {
-public: AffineInputs() : InputsRole(InputsRoles::AFFINE) { }
-};
-class SingularInput : public InputsRole {
-public: SingularInput() : InputsRole(InputsRoles::SINGULAR) { }
-};
-class AdditiveInputs : public InputsRole {
-public: AdditiveInputs() : InputsRole(InputsRoles::ADDITIVE) { }
-};
+class AffineInputs : public InputsRelationKindTrait<InputsRelationKind::AFFINE> { };
+class SingularInput : public InputsRelationKindTrait<InputsRelationKind::SINGULAR> { };
+class AdditiveInputs : public InputsRelationKindTrait<InputsRelationKind::ADDITIVE> { };
 
-inline std::ostream& operator<<(std::ostream& os, const InputsRoles& kind) {
+inline std::ostream& operator<<(std::ostream& os, const InputsRelationKind& kind) {
     switch (kind) {
-        case InputsRoles::AFFINE: os << "AFFINE"; break;
-        case InputsRoles::SINGULAR: os << "SINGULAR"; break;
-        case InputsRoles::ADDITIVE: os << "ADDITIVE"; break;
+        case InputsRelationKind::AFFINE: os << "AFFINE"; break;
+        case InputsRelationKind::SINGULAR: os << "SINGULAR"; break;
+        case InputsRelationKind::ADDITIVE: os << "ADDITIVE"; break;
         default: ARIADNE_FAIL_MSG("Unhandled InputsRoles for output streaming\n");
     }
     return os;

--- a/source/dynamics/differential_inclusion.hpp
+++ b/source/dynamics/differential_inclusion.hpp
@@ -177,15 +177,15 @@ inline std::ostream& operator << (std::ostream& os, const C1Norms& n) {
 
 C1Norms compute_norms(DifferentialInclusion const&, PositiveFloatDPValue const&, UpperBoxType const&);
 
-enum class InputApproximation : std::uint8_t { ZERO, CONSTANT, AFFINE, SINUSOIDAL, PIECEWISE };
+enum class InputApproximationKind : std::uint8_t { ZERO, CONSTANT, AFFINE, SINUSOIDAL, PIECEWISE };
 
-inline std::ostream& operator << (std::ostream& os, const InputApproximation& kind) {
+inline std::ostream& operator << (std::ostream& os, const InputApproximationKind& kind) {
     switch (kind) {
-        case InputApproximation::ZERO: os << "ZERO"; break;
-        case InputApproximation::CONSTANT: os << "CONSTANT"; break;
-        case InputApproximation::AFFINE: os << "AFFINE"; break;
-        case InputApproximation::SINUSOIDAL: os << "SINUSOIDAL"; break;
-        case InputApproximation::PIECEWISE: os << "PIECEWISE"; break;
+        case InputApproximationKind::ZERO: os << "ZERO"; break;
+        case InputApproximationKind::CONSTANT: os << "CONSTANT"; break;
+        case InputApproximationKind::AFFINE: os << "AFFINE"; break;
+        case InputApproximationKind::SINUSOIDAL: os << "SINUSOIDAL"; break;
+        case InputApproximationKind::PIECEWISE: os << "PIECEWISE"; break;
         default: ARIADNE_FAIL_MSG("Unhandled input approximation for output streaming\n");
     }
     return os;
@@ -193,27 +193,27 @@ inline std::ostream& operator << (std::ostream& os, const InputApproximation& ki
 
 class ParametricInputApproximation {
 protected:
-    ParametricInputApproximation(InputApproximation kind) : _kind(kind) { }
+    ParametricInputApproximation(InputApproximationKind kind) : _kind(kind) { }
 public:
-    InputApproximation kind() { return _kind; }
+    InputApproximationKind kind() { return _kind; }
 private:
-    InputApproximation _kind;
+    InputApproximationKind _kind;
 };
 
 class ZeroApproximation : public ParametricInputApproximation {
-public: ZeroApproximation() : ParametricInputApproximation(InputApproximation::ZERO) { }
+public: ZeroApproximation() : ParametricInputApproximation(InputApproximationKind::ZERO) { }
 };
 class ConstantApproximation : public ParametricInputApproximation {
-public: ConstantApproximation() : ParametricInputApproximation(InputApproximation::CONSTANT) { }
+public: ConstantApproximation() : ParametricInputApproximation(InputApproximationKind::CONSTANT) { }
 };
 class AffineApproximation : public ParametricInputApproximation {
-public: AffineApproximation() : ParametricInputApproximation(InputApproximation::AFFINE) { }
+public: AffineApproximation() : ParametricInputApproximation(InputApproximationKind::AFFINE) { }
 };
 class SinusoidalApproximation : public ParametricInputApproximation {
-public: SinusoidalApproximation() : ParametricInputApproximation(InputApproximation::SINUSOIDAL) { }
+public: SinusoidalApproximation() : ParametricInputApproximation(InputApproximationKind::SINUSOIDAL) { }
 };
 class PiecewiseApproximation : public ParametricInputApproximation {
-public: PiecewiseApproximation() : ParametricInputApproximation(InputApproximation::PIECEWISE) { }
+public: PiecewiseApproximation() : ParametricInputApproximation(InputApproximationKind::PIECEWISE) { }
 };
 
 template<class A> ErrorType r_value();
@@ -223,12 +223,12 @@ template<> ErrorType r_value<AffineApproximation>() { return ErrorType(5.0/3u); 
 template<> ErrorType r_value<SinusoidalApproximation>() { return ErrorType(5.0/4u); }
 template<> ErrorType r_value<PiecewiseApproximation>() { return ErrorType(1.3645_upper); }
 
-template<class A> constexpr InputApproximation approximation_kind();
-template<> constexpr InputApproximation approximation_kind<ZeroApproximation>() { return InputApproximation::ZERO; }
-template<> constexpr InputApproximation approximation_kind<ConstantApproximation>() { return InputApproximation::CONSTANT; }
-template<> constexpr InputApproximation approximation_kind<AffineApproximation>() { return InputApproximation::AFFINE; }
-template<> constexpr InputApproximation approximation_kind<SinusoidalApproximation>() { return InputApproximation::SINUSOIDAL; }
-template<> constexpr InputApproximation approximation_kind<PiecewiseApproximation>() { return InputApproximation::PIECEWISE; }
+template<class A> constexpr InputApproximationKind approximation_kind();
+template<> constexpr InputApproximationKind approximation_kind<ZeroApproximation>() { return InputApproximationKind::ZERO; }
+template<> constexpr InputApproximationKind approximation_kind<ConstantApproximation>() { return InputApproximationKind::CONSTANT; }
+template<> constexpr InputApproximationKind approximation_kind<AffineApproximation>() { return InputApproximationKind::AFFINE; }
+template<> constexpr InputApproximationKind approximation_kind<SinusoidalApproximation>() { return InputApproximationKind::SINUSOIDAL; }
+template<> constexpr InputApproximationKind approximation_kind<PiecewiseApproximation>() { return InputApproximationKind::PIECEWISE; }
 
 template<class A> constexpr Nat num_params_per_input();
 template<> constexpr Nat num_params_per_input<ZeroApproximation>() { return 0u; }
@@ -288,7 +288,7 @@ class InputApproximatorInterface;
 
 class InputApproximatorFactory {
 public:
-    InputApproximator create(DifferentialInclusion const& di, InputApproximation kind, SweeperDP sweeper) const;
+    InputApproximator create(DifferentialInclusion const& di, InputApproximationKind kind, SweeperDP sweeper) const;
 };
 
 template<class A> class ApproximationErrorProcessorInterface {
@@ -325,7 +325,7 @@ public:
 
 class InputApproximatorInterface {
   public:
-    virtual InputApproximation kind() const = 0;
+    virtual InputApproximationKind kind() const = 0;
     virtual Vector<ErrorType> compute_errors(PositiveFloatDPValue h, UpperBoxType const& B) const = 0;
     virtual BoxDomainType build_flow_domain(BoxDomainType D, BoxDomainType V, PositiveFloatDPValue h) const = 0;
     virtual Vector<ValidatedScalarFunction> build_w_functions(BoxDomainType DVh, SizeType n, SizeType m) const = 0;
@@ -341,7 +341,7 @@ class InputApproximator : public InputApproximatorInterface {
     InputApproximator(InputApproximator const& other) : _impl(other._impl) { }
     InputApproximator& operator=(InputApproximator const& other) { _impl = other._impl; return *this; }
   public:
-    virtual InputApproximation kind() const override { return _impl->kind(); }
+    virtual InputApproximationKind kind() const override { return _impl->kind(); }
     virtual Vector<ErrorType> compute_errors(PositiveFloatDPValue h, UpperBoxType const& B) const override { return _impl->compute_errors(h,B); }
     virtual BoxDomainType build_flow_domain(BoxDomainType D, BoxDomainType V, PositiveFloatDPValue h) const override { return _impl->build_flow_domain(D,V,h); }
     virtual Vector<ValidatedScalarFunction> build_w_functions(BoxDomainType DVh, SizeType n, SizeType m) const override { return _impl->build_w_functions(DVh,n,m); }
@@ -359,10 +359,10 @@ class InputApproximatorBase : public InputApproximatorInterface {
     InputApproximatorBase(DifferentialInclusion const& di, SweeperDP const& sweeper) :
         _di(di), _sweeper(sweeper), _processor(ApproximationErrorProcessorFactory<A>().create(di)), _kind(approximation_kind<A>()), _num_params_per_input(num_params_per_input<A>()) { }
   private:
-    const InputApproximation _kind;
+    const InputApproximationKind _kind;
     const Nat _num_params_per_input;
   public:
-    virtual InputApproximation kind() const override { return _kind; }
+    virtual InputApproximationKind kind() const override { return _kind; }
     virtual Vector<ErrorType> compute_errors(PositiveFloatDPValue h, UpperBoxType const& B) const override { return _processor->process(h,B); }
     virtual BoxDomainType build_flow_domain(BoxDomainType D, BoxDomainType V, PositiveFloatDPValue h) const override;
     virtual Vector<ValidatedScalarFunction> build_w_functions(BoxDomainType DVh, SizeType n, SizeType m) const override;
@@ -399,7 +399,7 @@ class InclusionIntegratorInterface {
 
 class InclusionIntegrator : public virtual InclusionIntegratorInterface, public Loggable {
   protected:
-    List<InputApproximation> _approximations;
+    List<InputApproximationKind> _approximations;
     SharedPointer<InputApproximator> _approximator;
     SharedPointer<Reconditioner> _reconditioner;
     SweeperDP _sweeper;
@@ -407,8 +407,8 @@ class InclusionIntegrator : public virtual InclusionIntegratorInterface, public 
     Nat _number_of_steps_between_simplifications;
     Nat _number_of_variables_to_keep;
   public:
-    InclusionIntegrator(List<InputApproximation> approximations, SweeperDP sweeper, StepSize step_size);
-    template<class... AS> InclusionIntegrator(List<InputApproximation> approximations, SweeperDP sweeper, StepSize step_size, AS... attributes);
+    InclusionIntegrator(List<InputApproximationKind> approximations, SweeperDP sweeper, StepSize step_size);
+    template<class... AS> InclusionIntegrator(List<InputApproximationKind> approximations, SweeperDP sweeper, StepSize step_size, AS... attributes);
   public:
     InclusionIntegrator& set(NumberOfStepsBetweenSimplifications n) { _number_of_steps_between_simplifications=n; return *this; }
     InclusionIntegrator& set(NumberOfVariablesToKeep n) { _number_of_variables_to_keep=n; return *this; }
@@ -426,7 +426,7 @@ class InclusionIntegrator : public virtual InclusionIntegratorInterface, public 
     Vector<ValidatedScalarFunction> build_secondhalf_piecewise_w_functions(BoxDomainType DVh, SizeType n, SizeType m) const;
 };
 
-template<class... AS> InclusionIntegrator::InclusionIntegrator(List<InputApproximation> approximations, SweeperDP sweeper, StepSize step_size_, AS... attributes)
+template<class... AS> InclusionIntegrator::InclusionIntegrator(List<InputApproximationKind> approximations, SweeperDP sweeper, StepSize step_size_, AS... attributes)
                 : InclusionIntegrator::InclusionIntegrator(approximations, sweeper,step_size_) {
     this->set(attributes...);
     _reconditioner.reset(new LohnerReconditioner(_sweeper,_number_of_variables_to_keep));

--- a/source/dynamics/differential_inclusion.hpp
+++ b/source/dynamics/differential_inclusion.hpp
@@ -360,7 +360,7 @@ public:
 class InclusionIntegratorInterface {
   public:
     virtual List<ValidatedVectorFunctionModelType> flow(DifferentialInclusionIVP const& di_ivp, Real T) = 0;
-    virtual Pair<ExactTimeStepType,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, ApproximateTimeStepType hsug) const = 0;
+    virtual Pair<ExactTimeStepType,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, ApproximateTimeStepType hsug) const = 0;
     virtual ValidatedVectorFunctionModelType reach(DifferentialInclusion const& di, BoxDomainType D, ValidatedVectorFunctionModelType evolve_function, UpperBoxType B, PositiveFloatDPValue t, PositiveFloatDPValue h) const = 0;
 };
 
@@ -383,7 +383,7 @@ class InclusionIntegrator : public virtual InclusionIntegratorInterface, public 
 
     virtual List<ValidatedVectorFunctionModelType> flow(DifferentialInclusionIVP const& di_ivp, Real T) override;
 
-    virtual Pair<ExactTimeStepType,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, ApproximateTimeStepType hsug) const override;
+    virtual Pair<ExactTimeStepType,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, ApproximateTimeStepType hsug) const override;
     virtual ValidatedVectorFunctionModelType reach(DifferentialInclusion const& di, BoxDomainType D, ValidatedVectorFunctionModelType evolve_function, UpperBoxType B, PositiveFloatDPValue t, PositiveFloatDPValue h) const override;
   private:
     ValidatedVectorFunctionModelType compute_flow_function(ValidatedVectorFunction const& dyn, BoxDomainType const& domain, UpperBoxType const& B) const;

--- a/source/geometry/box.hpp
+++ b/source/geometry/box.hpp
@@ -176,6 +176,7 @@ class Box
     static Box<I> _product(const Box<I>& bx1, const I& ivl2);
 
     static Box<I> _project(const Box<I>& bx, const Array<SizeType>& rng);
+    static Box<I> _project(const Box<I>& bx, const Range& rng);
 };
 
 template<class I> inline OutputStream& operator<<(OutputStream& os, const Box<I>& bx) {
@@ -214,6 +215,7 @@ UpperBoxType image(UpperBoxType bx, ValidatedVectorFunction const& f);
 //! \relates Box \brief Project onto the variables \a rng.
 template<class I> inline Box<I> project(const Box<I> & bx, Array<SizeType> const& rng) { return Box<I>::_project(bx,rng); }
 
+template<class I> inline Box<I> project(const Box<I> & bx, Range const& rng) { return Box<I>::_project(bx,rng); }
 
 template<class I> auto midpoint(const Box<I>& bx) -> typename Box<I>::MidpointType {
     return bx.midpoint();

--- a/source/geometry/box.tpl.hpp
+++ b/source/geometry/box.tpl.hpp
@@ -183,6 +183,15 @@ template<class I> Box<I> Box<I>::_project(const Box<I>& bx, const Array<SizeType
     return std::move(res);
 }
 
+template<class I> Box<I> Box<I>::_project(const Box<I>& bx, const Range& rng)
+{
+    Box<I> res(rng.size());
+    for(SizeType i=0; i!=rng.size(); ++i) {
+        res[i]=bx[rng[i]];
+    }
+    return std::move(res);
+}
+
 template<class I> Box<I> Box<I>::_product(const Box<I>& bx1, const Box<I>& bx2)
 {
     Box<I> r(bx1.size()+bx2.size());

--- a/source/solvers/CMakeLists.txt
+++ b/source/solvers/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ariadne-solvers OBJECT
     solver.cpp
     integrator.cpp
+    bounder.cpp
     constraint_solver.cpp
     simplex_algorithm.cpp
     linear_programming.cpp

--- a/source/solvers/bounder.cpp
+++ b/source/solvers/bounder.cpp
@@ -123,15 +123,4 @@ UpperBoxType RungeKutta4Bounder::formula(BoxDomainType D, BoxDomainType V, Valid
     return (k1+2*k2+2*k3+k4)/6;
 }
 
-BounderHandler BounderFactory::create(Bounder method) {
-    switch(method) {
-    case Bounder::EULER : return BounderHandler(SharedPointer<BounderInterface>(new EulerBounder()));
-    case Bounder::HEUN : return BounderHandler(SharedPointer<BounderInterface>(new HeunBounder()));
-    case Bounder::RALSTON : return BounderHandler(SharedPointer<BounderInterface>(new RalstonBounder()));
-    case Bounder::RUNGEKUTTA4 : return BounderHandler(SharedPointer<BounderInterface>(new RungeKutta4Bounder()));
-    default:
-        ARIADNE_FAIL_MSG("Unexpected flow bounds method "<<method<<"\n");
-    }
-}
-
 } // namespace Ariadne;

--- a/source/solvers/bounder.cpp
+++ b/source/solvers/bounder.cpp
@@ -26,7 +26,7 @@
 
 namespace Ariadne {
 
-Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
+Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::compute(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
     const PositiveFloatDPValue INITIAL_STARTING_WIDENING=cast_positive(2.0_exact);
     const PositiveFloatDPValue INITIAL_REFINING_WIDENING=cast_positive(1.125_exact);
     const PositiveFloatDPValue LIPSCHITZ_TOLERANCE=cast_positive(0.5_exact);

--- a/source/solvers/bounder.cpp
+++ b/source/solvers/bounder.cpp
@@ -29,7 +29,6 @@ namespace Ariadne {
 Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
     const PositiveFloatDPValue INITIAL_STARTING_WIDENING=cast_positive(2.0_exact);
     const PositiveFloatDPValue INITIAL_REFINING_WIDENING=cast_positive(1.125_exact);
-    const PositiveFloatDPValue NO_WIDENING=cast_positive(1.0_exact);
     const PositiveFloatDPValue LIPSCHITZ_TOLERANCE=cast_positive(0.5_exact);
     const Nat EXPANSION_STEPS=4;
     const Nat REFINEMENT_STEPS=4;
@@ -41,11 +40,12 @@ Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::flow_bounds(ValidatedVector
     h=cast_positive(min(hlip,h));
 
     UpperBoxType B;
+    UpperBoxType V(project(dom,range(f.result_size(),f.argument_size())));
     Bool success=false;
     while(!success) {
-        B=this->_initial(f,dom,h,INITIAL_STARTING_WIDENING);
+        B=this->_initial(dom,f,UpperBoxType(dom),h,INITIAL_STARTING_WIDENING);
         for(Nat i=0; i<EXPANSION_STEPS; ++i) {
-            UpperBoxType Br=this->_refinement(B,f,dom,h,NO_WIDENING);
+            UpperBoxType Br=this->_refinement(dom,f,B,h);
             if(not definitely(is_bounded(Br))) {
                 success=false;
                 break;
@@ -54,7 +54,8 @@ Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::flow_bounds(ValidatedVector
                 success=true;
                 break;
             } else {
-                B=this->_refinement(B,f,dom,h,INITIAL_REFINING_WIDENING);
+                UpperBoxType BV=product(B,V);
+                B=this->_initial(dom,f,BV,h,INITIAL_REFINING_WIDENING);
             }
         }
         if(!success) {
@@ -63,33 +64,33 @@ Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::flow_bounds(ValidatedVector
     }
 
     for(Nat i=0; i<REFINEMENT_STEPS; ++i) {
-        B = this->_refinement(B,f,dom,h,NO_WIDENING);
+        B = this->_refinement(dom,f,B,h);
     }
 
     return std::make_pair(h,B);
 }
 
-UpperBoxType BounderBase::_initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const {
+UpperBoxType BounderBase::_initial(BoxDomainType dom, ValidatedVectorFunction f, UpperBoxType arg, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const {
     const PositiveFloatDPValue BOX_RADIUS_WIDENING=cast_positive(0.25_exact);
     SizeType n = f.result_size();
     SizeType p = f.argument_size();
     BoxDomainType D = project(dom,range(0,n));
     BoxDomainType V = project(dom,range(n,p));
     UpperBoxType wD = D + BOX_RADIUS_WIDENING*(D-D.midpoint());
-    return wD + FORMULA_WIDENING*formula(D,V,f,UpperBoxType(dom),h);
+    return wD + FORMULA_WIDENING*formula(D,V,f,arg,h);
 }
 
-UpperBoxType BounderBase::_refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const {
+UpperBoxType BounderBase::_refinement(BoxDomainType dom, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
     SizeType n = f.result_size();
     SizeType p = f.argument_size();
     BoxDomainType D = project(dom,range(0,n));
     BoxDomainType V = project(dom,range(n,p));
     UpperBoxType BV = product(B,UpperBoxType(V));
-    return D + FORMULA_WIDENING*formula(D,V,f,BV,h);
+    return D + formula(D,V,f,BV,h);
 }
 
-UpperBoxType EulerBounder::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
-    return IntervalDomainType(0,h)*apply(f,B);
+UpperBoxType EulerBounder::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType arg, PositiveFloatDPValue h) const {
+    return IntervalDomainType(0,h)*apply(f,arg);
 }
 
 UpperBoxType HeunBounder::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {

--- a/source/solvers/bounder.cpp
+++ b/source/solvers/bounder.cpp
@@ -1,0 +1,92 @@
+/***************************************************************************
+ *            bounder.cpp
+ *
+ *  Copyright  2018  Luca Geretti
+ *
+ ****************************************************************************/
+
+/*
+ *  This file is part of Ariadne.
+ *
+ *  Ariadne is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Ariadne is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Ariadne.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "bounder.hpp"
+
+namespace Ariadne {
+
+UpperBoxType FlowBoundsMethodHandlerBase::initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+    SizeType n = f.result_size();
+    SizeType p = f.argument_size();
+    BoxDomainType D = project(dom,range(0,n));
+    BoxDomainType V = project(dom,range(n,p));
+    UpperBoxType wD = D + (D-D.midpoint());
+    return wD + 2*formula(D,V,f,UpperBoxType(dom),h);
+}
+
+UpperBoxType FlowBoundsMethodHandlerBase::refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+    SizeType n = f.result_size();
+    SizeType p = f.argument_size();
+    BoxDomainType D = project(dom,range(0,n));
+    BoxDomainType V = project(dom,range(n,p));
+    UpperBoxType BV = product(B,UpperBoxType(V));
+    return D + formula(D,V,f,BV,h);
+}
+
+UpperBoxType EulerFlowBoundsHandler::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
+    return IntervalDomainType(0,h)*apply(f,B);
+}
+
+UpperBoxType HeunFlowBoundsHandler::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
+    UpperBoxType k1 = IntervalDomainType(0,h)*apply(f,B);
+    UpperBoxType B2 = D + k1;
+    UpperBoxType BV2 = product(B2,UpperBoxType(V));
+    UpperBoxType k2 = IntervalDomainType(0,h)*apply(f,BV2);
+    return (k1+k2)/2;
+}
+
+UpperBoxType RalstonFlowBoundsHandler::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
+    UpperBoxType k1 = IntervalDomainType(0,h)*apply(f,B);
+    UpperBoxType B2 = D+2*k1/3;
+    UpperBoxType BV2 = product(B2,UpperBoxType(V));
+    UpperBoxType k2 = IntervalDomainType(0,h)*apply(f,BV2);
+    return (k1+3*k2)/4;
+}
+
+UpperBoxType RungeKutta4FlowBoundsHandler::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
+    UpperBoxType k1 = IntervalDomainType(0,h)*apply(f,B);
+    UpperBoxType B2 = D+k1/2;
+    UpperBoxType BV2 = product(B2,UpperBoxType(V));
+    UpperBoxType k2 = IntervalDomainType(0,h)*apply(f,BV2);
+    UpperBoxType B3 = D+k2/2;
+    UpperBoxType BV3 = product(B3,UpperBoxType(V));
+    UpperBoxType k3 = IntervalDomainType(0,h)*apply(f,BV3);
+    UpperBoxType B4 = D+k3;
+    UpperBoxType BV4 = product(B4,UpperBoxType(V));
+    UpperBoxType k4 = IntervalDomainType(0,h)*apply(f,BV4);
+    return (k1+2*k2+2*k3+k4)/6;
+}
+
+FlowBoundsMethodHandler FlowBoundsMethodHandlerFactory::create(FlowBoundsMethod method) {
+    switch(method) {
+    case FlowBoundsMethod::EULER : return FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface>(new EulerFlowBoundsHandler()));
+    case FlowBoundsMethod::HEUN : return FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface>(new HeunFlowBoundsHandler()));
+    case FlowBoundsMethod::RALSTON : return FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface>(new RalstonFlowBoundsHandler()));
+    case FlowBoundsMethod::RUNGEKUTTA4 : return FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface>(new RungeKutta4FlowBoundsHandler()));
+    default:
+        ARIADNE_FAIL_MSG("Unexpected flow bounds method "<<method<<"\n");
+    }
+}
+
+} // namespace Ariadne;

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -38,85 +38,85 @@
 
 namespace Ariadne {
 
-class FlowBoundsMethodHandlerFactory;
+class BounderFactory;
 
-class FlowBoundsMethodHandlerInterface {
+class BounderInterface {
   public:
-    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
+    virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const = 0;
 };
 
-class FlowBoundsMethodHandlerBase : public FlowBoundsMethodHandlerInterface {
+class BounderBase : public BounderInterface {
   public:
-    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+    Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const;
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const = 0;
-  public:
-    virtual ~FlowBoundsMethodHandlerBase() = default;
-};
-
-class EulerFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
-  protected:
-    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
-  public:
-    virtual ~EulerFlowBoundsHandler() = default;
-};
-
-class HeunFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
-  protected:
-    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
-  public:
-    virtual ~HeunFlowBoundsHandler() = default;
-};
-
-class RalstonFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
-  protected:
-    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
-  public:
-    virtual ~RalstonFlowBoundsHandler() = default;
-};
-
-class RungeKutta4FlowBoundsHandler : public FlowBoundsMethodHandlerBase {
-  protected:
-    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
-  public:
-    virtual ~RungeKutta4FlowBoundsHandler() = default;
-};
-
-class FlowBoundsMethodHandler : public FlowBoundsMethodHandlerInterface {
-    friend class FlowBoundsMethodHandlerFactory;
   private:
-    SharedPointer<FlowBoundsMethodHandlerInterface> _impl;
-    FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface> const& impl) : _impl(impl) { }
+    UpperBoxType _initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+    UpperBoxType _refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
   public:
-    FlowBoundsMethodHandler(FlowBoundsMethodHandler const& other) : _impl(other._impl) { }
-    FlowBoundsMethodHandler& operator=(FlowBoundsMethodHandler const& other) { _impl = other._impl; return *this; }
-
-    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        return _impl->initial(f,dom,h); }
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        return _impl->refinement(B,f,dom,h); }
-  public:
-    virtual ~FlowBoundsMethodHandler() = default;
+    virtual ~BounderBase() = default;
 };
 
-enum class FlowBoundsMethod : std::uint8_t { EULER, HEUN, RALSTON, RUNGEKUTTA4 };
+class EulerBounder : public BounderBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~EulerBounder() = default;
+};
 
-inline std::ostream& operator << (std::ostream& os, const FlowBoundsMethod& kind) {
+class HeunBounder : public BounderBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~HeunBounder() = default;
+};
+
+class RalstonBounder : public BounderBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~RalstonBounder() = default;
+};
+
+class RungeKutta4Bounder : public BounderBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~RungeKutta4Bounder() = default;
+};
+
+class BounderHandler : public BounderInterface {
+    friend class BounderFactory;
+  private:
+    SharedPointer<BounderInterface> _impl;
+    BounderHandler(SharedPointer<BounderInterface> const& impl) : _impl(impl) { }
+  public:
+    BounderHandler(BounderHandler const& other) : _impl(other._impl) { }
+    BounderHandler& operator=(BounderHandler const& other) { _impl = other._impl; return *this; }
+
+    virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
+        return _impl->flow_bounds(f,dom,hsug);
+    }
+  public:
+    virtual ~BounderHandler() = default;
+};
+
+enum class Bounder : std::uint8_t { EULER, HEUN, RALSTON, RUNGEKUTTA4 };
+
+inline std::ostream& operator << (std::ostream& os, const Bounder& kind) {
     switch (kind) {
-        case FlowBoundsMethod::EULER: os << "EULER"; break;
-        case FlowBoundsMethod::HEUN: os << "HEUN"; break;
-        case FlowBoundsMethod::RALSTON: os << "RALSTON"; break;
-        case FlowBoundsMethod::RUNGEKUTTA4: os << "RUNGEKUTTA4"; break;
-        default: ARIADNE_FAIL_MSG("Unhandled flow bounds method for output streaming\n");
+        case Bounder::EULER: os << "EULER"; break;
+        case Bounder::HEUN: os << "HEUN"; break;
+        case Bounder::RALSTON: os << "RALSTON"; break;
+        case Bounder::RUNGEKUTTA4: os << "RUNGEKUTTA4"; break;
+        default: ARIADNE_FAIL_MSG("Unhandled bounder method for output streaming\n");
     }
     return os;
 }
 
-class FlowBoundsMethodHandlerFactory {
+class BounderFactory {
 public:
-    static FlowBoundsMethodHandler create(FlowBoundsMethod method);
+    static BounderHandler create(Bounder method);
 };
 
 

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -51,8 +51,8 @@ class BounderBase : public BounderInterface {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const = 0;
   private:
-    UpperBoxType _initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
-    UpperBoxType _refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+    UpperBoxType _initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const;
+    UpperBoxType _refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const;
   public:
     virtual ~BounderBase() = default;
 };

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -83,22 +83,21 @@ class RungeKutta4Bounder : public BounderBase {
     virtual ~RungeKutta4Bounder() = default;
 };
 
-class BounderHandler : public BounderInterface {
+class BounderHandle : public BounderInterface {
     friend class BounderFactory;
   private:
     SharedPointer<BounderInterface> _impl;
-    BounderHandler(SharedPointer<BounderInterface> const& impl) : _impl(impl) { }
   public:
-    BounderHandler(BounderHandler const& other) : _impl(other._impl) { }
-    BounderHandler& operator=(BounderHandler const& other) { _impl = other._impl; return *this; }
+    BounderHandle(SharedPointer<BounderInterface> const& impl) : _impl(impl) { }
+    BounderHandle(BounderHandle const& other) : _impl(other._impl) { }
+    BounderHandle& operator=(BounderHandle const& other) { _impl = other._impl; return *this; }
 
     virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
         return _impl->flow_bounds(f,dom,hsug);
     }
   public:
-    virtual ~BounderHandler() = default;
+    virtual ~BounderHandle() = default;
 };
-
 
 } // namespace Ariadne
 

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -38,8 +38,6 @@
 
 namespace Ariadne {
 
-class BounderFactory;
-
 class BounderInterface {
   public:
     virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const = 0;
@@ -99,24 +97,6 @@ class BounderHandler : public BounderInterface {
     }
   public:
     virtual ~BounderHandler() = default;
-};
-
-enum class Bounder : std::uint8_t { EULER, HEUN, RALSTON, RUNGEKUTTA4 };
-
-inline std::ostream& operator << (std::ostream& os, const Bounder& kind) {
-    switch (kind) {
-        case Bounder::EULER: os << "EULER"; break;
-        case Bounder::HEUN: os << "HEUN"; break;
-        case Bounder::RALSTON: os << "RALSTON"; break;
-        case Bounder::RUNGEKUTTA4: os << "RUNGEKUTTA4"; break;
-        default: ARIADNE_FAIL_MSG("Unhandled bounder method for output streaming\n");
-    }
-    return os;
-}
-
-class BounderFactory {
-public:
-    static BounderHandler create(Bounder method);
 };
 
 

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -1,0 +1,125 @@
+/***************************************************************************
+ *            bounder.hpp
+ *
+ *  Copyright  2018  Luca Geretti
+ *
+ ****************************************************************************/
+
+/*
+ *  This file is part of Ariadne.
+ *
+ *  Ariadne is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Ariadne is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Ariadne.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*! \file bounder.hpp
+ *  \brief Classes for finding the bounds of the flow for differential equations.
+ */
+
+#ifndef ARIADNE_BOUNDER_HPP
+#define ARIADNE_BOUNDER_HPP
+
+#include "../utility/typedefs.hpp"
+#include "../utility/attribute.hpp"
+#include "../algebra/algebra.hpp"
+#include "../function/domain.hpp"
+#include "../function/function_model.hpp"
+#include "../output/logging.hpp"
+
+namespace Ariadne {
+
+class FlowBoundsMethodHandlerFactory;
+
+class FlowBoundsMethodHandlerInterface {
+  public:
+    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
+};
+
+class FlowBoundsMethodHandlerBase : public FlowBoundsMethodHandlerInterface {
+  public:
+    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const = 0;
+  public:
+    virtual ~FlowBoundsMethodHandlerBase() = default;
+};
+
+class EulerFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~EulerFlowBoundsHandler() = default;
+};
+
+class HeunFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~HeunFlowBoundsHandler() = default;
+};
+
+class RalstonFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~RalstonFlowBoundsHandler() = default;
+};
+
+class RungeKutta4FlowBoundsHandler : public FlowBoundsMethodHandlerBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~RungeKutta4FlowBoundsHandler() = default;
+};
+
+class FlowBoundsMethodHandler : public FlowBoundsMethodHandlerInterface {
+    friend class FlowBoundsMethodHandlerFactory;
+  private:
+    SharedPointer<FlowBoundsMethodHandlerInterface> _impl;
+    FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface> const& impl) : _impl(impl) { }
+  public:
+    FlowBoundsMethodHandler(FlowBoundsMethodHandler const& other) : _impl(other._impl) { }
+    FlowBoundsMethodHandler& operator=(FlowBoundsMethodHandler const& other) { _impl = other._impl; return *this; }
+
+    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+        return _impl->initial(f,dom,h); }
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+        return _impl->refinement(B,f,dom,h); }
+  public:
+    virtual ~FlowBoundsMethodHandler() = default;
+};
+
+enum class FlowBoundsMethod : std::uint8_t { EULER, HEUN, RALSTON, RUNGEKUTTA4 };
+
+inline std::ostream& operator << (std::ostream& os, const FlowBoundsMethod& kind) {
+    switch (kind) {
+        case FlowBoundsMethod::EULER: os << "EULER"; break;
+        case FlowBoundsMethod::HEUN: os << "HEUN"; break;
+        case FlowBoundsMethod::RALSTON: os << "RALSTON"; break;
+        case FlowBoundsMethod::RUNGEKUTTA4: os << "RUNGEKUTTA4"; break;
+        default: ARIADNE_FAIL_MSG("Unhandled flow bounds method for output streaming\n");
+    }
+    return os;
+}
+
+class FlowBoundsMethodHandlerFactory {
+public:
+    static FlowBoundsMethodHandler create(FlowBoundsMethod method);
+};
+
+
+} // namespace Ariadne
+
+#endif /* ARIADNE_BOUNDER_HPP */

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -40,12 +40,16 @@ namespace Ariadne {
 
 class BounderInterface {
   public:
-    virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const = 0;
+    virtual Pair<PositiveFloatDPValue,UpperBoxType> compute(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const = 0;
+    virtual Void write(OutputStream& os) const = 0;
+
+    friend inline OutputStream& operator<<(OutputStream& os, const BounderInterface& bounder) {
+        bounder.write(os); return os; }
 };
 
-class BounderBase : public BounderInterface {
+class BounderBase : public BounderInterface, Loggable {
   public:
-    Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const;
+    virtual Pair<PositiveFloatDPValue,UpperBoxType> compute(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const;
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const = 0;
   private:
@@ -53,12 +57,14 @@ class BounderBase : public BounderInterface {
     UpperBoxType _refinement(BoxDomainType dom, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
     virtual ~BounderBase() = default;
+
 };
 
 class EulerBounder : public BounderBase {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
+    virtual Void write(OutputStream& os) const { os << "Euler"; }
     virtual ~EulerBounder() = default;
 };
 
@@ -66,6 +72,7 @@ class HeunBounder : public BounderBase {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
+    virtual Void write(OutputStream& os) const { os << "Heun"; }
     virtual ~HeunBounder() = default;
 };
 
@@ -73,6 +80,7 @@ class RalstonBounder : public BounderBase {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
+    virtual Void write(OutputStream& os) const { os << "Ralston"; }
     virtual ~RalstonBounder() = default;
 };
 
@@ -80,6 +88,7 @@ class RungeKutta4Bounder : public BounderBase {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
+    virtual Void write(OutputStream& os) const { os << "RungeKutta4"; }
     virtual ~RungeKutta4Bounder() = default;
 };
 
@@ -92,12 +101,16 @@ class BounderHandle : public BounderInterface {
     BounderHandle(BounderHandle const& other) : _impl(other._impl) { }
     BounderHandle& operator=(BounderHandle const& other) { _impl = other._impl; return *this; }
 
-    virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
-        return _impl->flow_bounds(f,dom,hsug);
+    virtual Void write(OutputStream& os) const { _impl->write(os); }
+
+    virtual Pair<PositiveFloatDPValue,UpperBoxType> compute(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
+        return _impl->compute(f,dom,hsug);
     }
   public:
     virtual ~BounderHandle() = default;
 };
+
+
 
 } // namespace Ariadne
 

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -51,8 +51,8 @@ class BounderBase : public BounderInterface {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const = 0;
   private:
-    UpperBoxType _initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const;
-    UpperBoxType _refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const;
+    UpperBoxType _initial(BoxDomainType dom, ValidatedVectorFunction f, UpperBoxType arg, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const;
+    UpperBoxType _refinement(BoxDomainType dom, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
     virtual ~BounderBase() = default;
 };

--- a/source/solvers/integrator.cpp
+++ b/source/solvers/integrator.cpp
@@ -94,7 +94,7 @@ IntegratorBase::function_factory() const
 
 Pair<FloatDPValue,UpperBoxType>
 IntegratorBase::flow_bounds(const ValidatedVectorFunction& vf, const ExactBoxType& domx, const RawFloatDP& hsug) const {
-    return EulerBounder().flow_bounds(vf,domx,PositiveFloatDPApproximation(hsug));
+    return EulerBounder().compute(vf,domx,PositiveFloatDPApproximation(hsug));
 }
 
 

--- a/source/solvers/integrator.cpp
+++ b/source/solvers/integrator.cpp
@@ -28,6 +28,7 @@
 #include <iomanip>
 
 #include "../solvers/integrator.hpp"
+#include "../solvers/bounder.hpp"
 
 #include "../output/logging.hpp"
 #include "../utility/container.hpp"
@@ -92,91 +93,8 @@ IntegratorBase::function_factory() const
 }
 
 Pair<FloatDPValue,UpperBoxType>
-IntegratorBase::flow_bounds(const ValidatedVectorFunction& vf, const ExactBoxType& domx, const RawFloatDP& hsug) const
-{
-    ARIADNE_LOG(3,"IntegratorBase::flow_bounds(ValidatedVectorFunction vf, ExactBoxType domx, FloatDP hmax)\n");
-    ARIADNE_ASSERT_MSG(vf.result_size()==domx.size(),"vector_field="<<vf<<", states="<<domx);
-    ARIADNE_ASSERT_MSG(vf.argument_size()==domx.size(),"vector_field="<<vf<<", states="<<domx);
-    ARIADNE_ASSERT(hsug>0);
-
-
-    // Set up constants of the method.
-    // TODO: Better estimates of constants
-    const FloatDPValue INITIAL_MULTIPLIER=2.0_exact;
-    const FloatDPValue MULTIPLIER=1.125_exact;
-    const FloatDPValue BOX_RADIUS_WIDENING=0.25_exact;
-    const Nat EXPANSION_STEPS=4;
-    const Nat REDUCTION_STEPS=8;
-    const Nat REFINEMENT_STEPS=4;
-
-    Vector<FloatDPBounds> const& dx=cast_singleton(domx);
-
-    Vector<UpperIntervalType> delta=(domx-midpoint(domx))*BOX_RADIUS_WIDENING;
-
-    // Compute the Lipschitz constant over the initial box
-    FloatDPUpperBound lip = norm(vf.jacobian(dx)).upper();
-    FloatDPValue hlip = cast_exact(this->_lipschitz_tolerance/lip);
-
-    FloatDPValue hmax(FloatDP(this->maximum_step_size()));
-    FloatDPValue h=cast_exact(hsug);
-    FloatDPValue hmin=h*(two^-REDUCTION_STEPS);
-    h=max(hmin,min(hmax,min(hlip,h)));
-    ARIADNE_LOG(4,"L="<<lip<<", hL="<<hlip<<", hmax="<<hmax<<"\n");
-
-    UpperBoxType bx,nbx;
-    Vector<UpperIntervalType> df;
-    UpperIntervalType ih(0,h);
-
-    Bool success=false;
-    while(!success) {
-        ARIADNE_ASSERT_MSG(h>=hmin," h="<<h<<", hmin="<<hmin);
-        bx=domx+INITIAL_MULTIPLIER*ih*vf.evaluate(dx)+delta;
-        for(Nat i=0; i!=EXPANSION_STEPS; ++i) {
-            df=apply(vf,bx);
-            nbx=domx+delta+ih*df;
-            ARIADNE_LOG(7,"h="<<h<<" nbx="<<nbx<<" bx="<<bx<<"\n");
-            if(not definitely(is_bounded(nbx))) {
-                success=false;
-                break;
-            } else if(refines(nbx,bx)) {
-                success=true;
-                break;
-            } else {
-                bx=domx+delta+MULTIPLIER*ih*df;
-            }
-        }
-        if(!success) {
-            h=hlf(h);
-            ih=UpperIntervalType(0,h);
-        }
-    }
-
-    ARIADNE_ASSERT(refines(nbx,bx));
-
-    Vector<UpperIntervalType> vfbx;
-    vfbx=apply(vf,bx);
-
-    for(Nat i=0; i!=REFINEMENT_STEPS; ++i) {
-        bx=nbx;
-        vfbx=apply(vf,bx);
-        nbx=domx+delta+ih*vfbx;
-        ARIADNE_ASSERT_MSG(refines(nbx,bx),std::setprecision(20)<<"refinement "<<i<<": "<<nbx<<" is not a inside of "<<bx);
-    }
-
-
-    // Check result of operation
-    // We use subset rather than inner subset here since the bound may touch
-    ARIADNE_ASSERT(refines(nbx,bx));
-
-    bx=nbx;
-
-
-    ARIADNE_ASSERT(refines(domx,bx));
-
-    ARIADNE_ASSERT_MSG(refines(domx+ih*apply(vf,bx),bx),
-        "d="<<dx<<"\nh="<<h<<"\nf(b)="<<apply(vf,bx)<<"\nd+hf(b)="<<(domx+ih*apply(vf,bx))<<"\nb="<<bx<<"\n");
-
-    return std::make_pair(FloatDPValue(h),bx);
+IntegratorBase::flow_bounds(const ValidatedVectorFunction& vf, const ExactBoxType& domx, const RawFloatDP& hsug) const {
+    return EulerBounder().flow_bounds(vf,domx,PositiveFloatDPApproximation(hsug));
 }
 
 

--- a/tests/dynamics/test_differential_inclusion.cpp
+++ b/tests/dynamics/test_differential_inclusion.cpp
@@ -137,6 +137,7 @@ void TestInclusionIntegrator::test() const {
 }
 
 int main() {
+
     TestInclusionIntegrator().test();
     return ARIADNE_TEST_FAILURES;
 }

--- a/tests/dynamics/test_differential_inclusion.cpp
+++ b/tests/dynamics/test_differential_inclusion.cpp
@@ -41,16 +41,16 @@ using namespace Ariadne;
 
 class TestInclusionIntegrator {
 
-    Void run_each_approximation(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximation> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity) const
+    Void run_each_approximation(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximationKind> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity) const
     {
         for (auto appro: approximations) {
-            List<InputApproximation> singleapproximation = {appro};
+            List<InputApproximationKind> singleapproximation = {appro};
             std::cout << appro << std::endl;
             run_single_test(name,ivp,evolution_time,step,singleapproximation,sweeper,freq,verbosity);
         }
     }
 
-    Void run_single_test(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximation> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity) const
+    Void run_single_test(String name, DifferentialInclusionIVP const& ivp, Real evolution_time, double step, List<InputApproximationKind> approximations, SweeperDP sweeper, SizeType freq, unsigned int verbosity) const
     {
         auto integrator = InclusionIntegrator(approximations,sweeper,step_size=step,number_of_steps_between_simplifications=freq,number_of_variables_to_keep=20000);
         integrator.verbosity = verbosity;
@@ -66,12 +66,12 @@ class TestInclusionIntegrator {
         ThresholdSweeperDP sweeper(DoublePrecision(),1e-8);
         unsigned int verbosity = 0;
 
-        List<InputApproximation> approximations;
-        approximations.append(InputApproximation::ZERO);
-        approximations.append(InputApproximation::CONSTANT);
-        approximations.append(InputApproximation::AFFINE);
-        approximations.append(InputApproximation::SINUSOIDAL);
-        approximations.append(InputApproximation::PIECEWISE);
+        List<InputApproximationKind> approximations;
+        approximations.append(InputApproximationKind::ZERO);
+        approximations.append(InputApproximationKind::CONSTANT);
+        approximations.append(InputApproximationKind::AFFINE);
+        approximations.append(InputApproximationKind::SINUSOIDAL);
+        approximations.append(InputApproximationKind::PIECEWISE);
 
         this->run_each_approximation(name,ivp,evolution_time,step,approximations,sweeper,freq,verbosity);
     }


### PR DESCRIPTION
I implemented the Bounder functionality, no enum classes defined. For simplicity, these commits also include previous minor refactorings of the DI code: just ignore them and focus on the files in the solvers module.

For the time being, the Bounder class is used as the implementation of flow_bounds in both the Integrator and DifferentialInclusionIntegrator, so we have a unique implementation. As for he routine that calculates the bounds, I used IntegratorBase::flow_bounds as reference. While the "simplified" one from DifferentialInclusionIntegrator worked well on the DI examples, it wasn't robust enough for  test_hybrid_reachability_analyser: using it made the test require ~13 times the execution time as usual, i.e., the step size chosen was smaller than necessary.