### PR TITLE
Implementation of Bounder

### DIFF
--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -786,14 +786,18 @@ class EulerFlowBoundsHandler : public FlowBoundsMethodHandlerBase<FlowBoundsMeth
 class HeunFlowBoundsHandler : public FlowBoundsMethodHandlerBase<FlowBoundsMethod::HEUN> {
   protected:
     virtual UpperBoxType _initial(UpperBoxType wD, BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        UpperBoxType B_end = D + IntervalDomainType(0,h)*apply(f,dom);
-        UpperBoxType BV_end = product(B_end,UpperBoxType(V));
-        return wD + IntervalDomainType(0,h)*(apply(f,dom)+apply(f,BV_end));
+        UpperBoxType k1 = IntervalDomainType(0,h)*apply(f,dom);
+        UpperBoxType B2 = D + k1;
+        UpperBoxType BV2 = product(B2,UpperBoxType(V));
+        UpperBoxType k2 = IntervalDomainType(0,h)*apply(f,BV2);
+        return wD + k1+k2;
     }
     virtual UpperBoxType _refinement(BoxDomainType D, BoxDomainType V, UpperBoxType BV, UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        UpperBoxType B_end = D + IntervalDomainType(0,h)*apply(f,BV);
-        UpperBoxType BV_end = product(B_end,UpperBoxType(V));
-        return D + IntervalDomainType(0,h)/2*(apply(f,BV)+apply(f,BV_end));
+        UpperBoxType k1 = IntervalDomainType(0,h)*apply(f,BV);
+        UpperBoxType B2 = D+k1;
+        UpperBoxType BV2 = product(B2,UpperBoxType(V));
+        UpperBoxType k2 = IntervalDomainType(0,h)*apply(f,BV2);
+        return D + (k1+k2)/2;
     }
   public:
     virtual ~HeunFlowBoundsHandler() = default;

--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -711,22 +711,7 @@ ValidatedVectorFunction build_Fw(ValidatedVectorFunction const& F, Vector<Valida
 
 
 Pair<PositiveFloatDPValue,UpperBoxType> InclusionIntegrator::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
-
-    PositiveFloatDPValue h=cast_exact(hsug);
-
-    RalstonFlowBoundsHandler fbh;
-
-    UpperBoxType B = fbh.initial(f,dom,h);
-
-    while(not refines(fbh.refinement(B,f,dom,h),B)) {
-        h=hlf(h);
-    }
-
-    for(Nat i=0; i<4; ++i) {
-        B = fbh.refinement(B,f,dom,h);
-    }
-
-    return std::make_pair(h,B);
+    return RalstonBounder().flow_bounds(f,dom,hsug);
 }
 
 

--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -711,7 +711,7 @@ ValidatedVectorFunction build_Fw(ValidatedVectorFunction const& F, Vector<Valida
 
 
 Pair<PositiveFloatDPValue,UpperBoxType> InclusionIntegrator::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
-    return EulerBounder().flow_bounds(f,dom,hsug);
+    return EulerBounder().compute(f,dom,hsug);
 }
 
 

--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -446,7 +446,9 @@ List<ValidatedVectorFunctionModelDP> InclusionIntegrator::flow(DifferentialInclu
         UpperBoxType B;
         PositiveFloatDPValue h;
 
-        std::tie(h,B)=this->flow_bounds(F,V,D,hsug);
+        BoxDomainType dom = product(D,V);
+
+        std::tie(h,B)=this->flow_bounds(F,dom,hsug);
         ARIADNE_LOG(3,"flow bounds = "<<B<<" (using h = " << h << ")\n");
 
         PositiveFloatDPValue new_t=cast_positive(cast_exact((t+h).lower()));
@@ -709,18 +711,34 @@ ValidatedVectorFunction build_Fw(ValidatedVectorFunction const& F, Vector<Valida
 
 class FlowBoundsMethodInterface {
   public:
-    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, PositiveFloatDPValue h) const = 0;
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, PositiveFloatDPValue h) const = 0;
+    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
+};
+
+class FlowBoundsMethodBase : public FlowBoundsMethodInterface {
+  public:
+    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+  protected:
+    virtual UpperBoxType _initial(ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, PositiveFloatDPValue h) const;
+    virtual UpperBoxType _refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, PositiveFloatDPValue h) const;
+  public:
+    virtual ~FlowBoundsMethodBase() = default;
 };
 
 class EulerFlowBoundsMethod : public FlowBoundsMethodInterface {
   public:
-    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, PositiveFloatDPValue h) const {
+    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+        SizeType n = f.result_size();
+        BoxDomainType D = project(dom,range(0,n));
         UpperBoxType wD = D + (D-D.midpoint());
-        ExactBoxType DV = product(D,V);
-        return wD + 2*IntervalDomainType(0,h)*apply(f,DV);
+        return wD + 2*IntervalDomainType(0,h)*apply(f,dom);
     }
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, PositiveFloatDPValue h) const {
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+        SizeType n = f.result_size();
+        SizeType p = f.argument_size();
+        BoxDomainType D = project(dom,range(0,n));
+        BoxDomainType V = project(dom,range(n,p));
         UpperBoxType BV = product(B,UpperBoxType(V));
         return D + IntervalDomainType(0,h)*apply(f,BV);
     }
@@ -730,14 +748,21 @@ class EulerFlowBoundsMethod : public FlowBoundsMethodInterface {
 
 class HeunFlowBoundsMethod : public FlowBoundsMethodInterface {
   public:
-    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, PositiveFloatDPValue h) const {
+    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+        SizeType n = f.result_size();
+        SizeType p = f.argument_size();
+        BoxDomainType D = project(dom,range(0,n));
+        BoxDomainType V = project(dom,range(n,p));
         UpperBoxType wD = D + (D-D.midpoint());
-        ExactBoxType DV = product(D,V);
-        UpperBoxType B_end = D + IntervalDomainType(0,h)*apply(f,DV);
+        UpperBoxType B_end = D + IntervalDomainType(0,h)*apply(f,dom);
         UpperBoxType BV_end = product(B_end,UpperBoxType(V));
-        return wD + IntervalDomainType(0,h)*(apply(f,DV)+apply(f,BV_end));
+        return wD + IntervalDomainType(0,h)*(apply(f,dom)+apply(f,BV_end));
     }
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, PositiveFloatDPValue h) const {
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+        SizeType n = f.result_size();
+        SizeType p = f.argument_size();
+        BoxDomainType D = project(dom,range(0,n));
+        BoxDomainType V = project(dom,range(n,p));
         UpperBoxType BV = product(B,UpperBoxType(V));
         UpperBoxType B_end = D + IntervalDomainType(0,h)*apply(f,BV);
         UpperBoxType BV_end = product(B_end,UpperBoxType(V));
@@ -748,20 +773,20 @@ class HeunFlowBoundsMethod : public FlowBoundsMethodInterface {
 };
 
 
-Pair<PositiveFloatDPValue,UpperBoxType> InclusionIntegrator::flow_bounds(ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, PositiveFloatDPApproximation hsug) const {
+Pair<PositiveFloatDPValue,UpperBoxType> InclusionIntegrator::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
 
     PositiveFloatDPValue h=cast_exact(hsug);
 
     EulerFlowBoundsMethod is;
 
-    UpperBoxType B = is.initial(f,V,D,h);
+    UpperBoxType B = is.initial(f,dom,h);
 
-    while(not refines(is.refinement(B,f,V,D,h),B)) {
+    while(not refines(is.refinement(B,f,dom,h),B)) {
         h=hlf(h);
     }
 
     for(Nat i=0; i<4; ++i) {
-        B = is.refinement(B,f,V,D,h);
+        B = is.refinement(B,f,dom,h);
     }
 
     return std::make_pair(h,B);

--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -711,7 +711,7 @@ ValidatedVectorFunction build_Fw(ValidatedVectorFunction const& F, Vector<Valida
 
 
 Pair<PositiveFloatDPValue,UpperBoxType> InclusionIntegrator::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
-    return RalstonBounder().flow_bounds(f,dom,hsug);
+    return EulerBounder().flow_bounds(f,dom,hsug);
 }
 
 

--- a/source/dynamics/differential_inclusion.cpp
+++ b/source/dynamics/differential_inclusion.cpp
@@ -352,7 +352,6 @@ template<class A, class R> Vector<ErrorType> ApproximationErrorProcessor<A,R>::p
 
 InputApproximator
 InputApproximatorFactory::create(DifferentialInclusion const& di, InputApproximation kind, SweeperDP sweeper) const {
-
     switch(kind) {
     case InputApproximation::ZERO : return InputApproximator(SharedPointer<InputApproximatorInterface>(new InputApproximatorBase<ZeroApproximation>(di,sweeper)));
     case InputApproximation::CONSTANT : return InputApproximator(SharedPointer<InputApproximatorInterface>(new InputApproximatorBase<ConstantApproximation>(di,sweeper)));
@@ -709,6 +708,17 @@ ValidatedVectorFunction build_Fw(ValidatedVectorFunction const& F, Vector<Valida
     return compose(F,substitution);
 }
 
+enum class FlowBoundsMethodKind : std::uint8_t { EULER, HEUN };
+
+inline std::ostream& operator << (std::ostream& os, const FlowBoundsMethodKind& kind) {
+    switch (kind) {
+        case FlowBoundsMethodKind::EULER: os << "EULER"; break;
+        case FlowBoundsMethodKind::HEUN: os << "HEUN"; break;
+        default: ARIADNE_FAIL_MSG("Unhandled flow bounds method kind for output streaming\n");
+    }
+    return os;
+}
+
 class FlowBoundsMethodInterface {
   public:
     virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
@@ -717,76 +727,106 @@ class FlowBoundsMethodInterface {
 
 class FlowBoundsMethodBase : public FlowBoundsMethodInterface {
   public:
-    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+        SizeType n = f.result_size();
+        SizeType p = f.argument_size();
+        BoxDomainType D = project(dom,range(0,n));
+        BoxDomainType V = project(dom,range(n,p));
+        UpperBoxType wD = D + (D-D.midpoint());
+        return _initial(wD,D,V,f,dom,h);
+    }
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+        SizeType n = f.result_size();
+        SizeType p = f.argument_size();
+        BoxDomainType D = project(dom,range(0,n));
+        BoxDomainType V = project(dom,range(n,p));
+        UpperBoxType BV = product(B,UpperBoxType(V));
+        return _refinement(D,V,BV,B,f,dom,h);
+    }
   protected:
-    virtual UpperBoxType _initial(ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, PositiveFloatDPValue h) const;
-    virtual UpperBoxType _refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, PositiveFloatDPValue h) const;
+    virtual UpperBoxType _initial(UpperBoxType wD, BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
+    virtual UpperBoxType _refinement(BoxDomainType D, BoxDomainType V, UpperBoxType BV, UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
   public:
     virtual ~FlowBoundsMethodBase() = default;
 };
 
-class EulerFlowBoundsMethod : public FlowBoundsMethodInterface {
+class FlowBoundsMethodFactory;
+
+class FlowBoundsMethod : public FlowBoundsMethodInterface {
+    friend class FlowBoundsMethodFactory;
+  private:
+    SharedPointer<FlowBoundsMethodInterface> _impl;
+    FlowBoundsMethod(SharedPointer<FlowBoundsMethodInterface> const& impl) : _impl(impl) { }
   public:
+    FlowBoundsMethod(FlowBoundsMethod const& other) : _impl(other._impl) { }
+    FlowBoundsMethod& operator=(FlowBoundsMethod const& other) { _impl = other._impl; return *this; }
+
     virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        SizeType n = f.result_size();
-        BoxDomainType D = project(dom,range(0,n));
-        UpperBoxType wD = D + (D-D.midpoint());
+        return _impl->initial(f,dom,h); }
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+        return _impl->refinement(B,f,dom,h); }
+  public:
+    virtual ~FlowBoundsMethod() = default;
+};
+
+class EulerFlowBoundsMethod : public FlowBoundsMethodBase {
+  protected:
+    virtual UpperBoxType _initial(UpperBoxType wD, BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
         return wD + 2*IntervalDomainType(0,h)*apply(f,dom);
     }
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        SizeType n = f.result_size();
-        SizeType p = f.argument_size();
-        BoxDomainType D = project(dom,range(0,n));
-        BoxDomainType V = project(dom,range(n,p));
-        UpperBoxType BV = product(B,UpperBoxType(V));
+    virtual UpperBoxType _refinement(BoxDomainType D, BoxDomainType V, UpperBoxType BV, UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
         return D + IntervalDomainType(0,h)*apply(f,BV);
     }
-
+  public:
     virtual ~EulerFlowBoundsMethod() = default;
 };
 
-class HeunFlowBoundsMethod : public FlowBoundsMethodInterface {
-  public:
-    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        SizeType n = f.result_size();
-        SizeType p = f.argument_size();
-        BoxDomainType D = project(dom,range(0,n));
-        BoxDomainType V = project(dom,range(n,p));
-        UpperBoxType wD = D + (D-D.midpoint());
+class HeunFlowBoundsMethod : public FlowBoundsMethodBase {
+  protected:
+    virtual UpperBoxType _initial(UpperBoxType wD, BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
         UpperBoxType B_end = D + IntervalDomainType(0,h)*apply(f,dom);
         UpperBoxType BV_end = product(B_end,UpperBoxType(V));
         return wD + IntervalDomainType(0,h)*(apply(f,dom)+apply(f,BV_end));
     }
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        SizeType n = f.result_size();
-        SizeType p = f.argument_size();
-        BoxDomainType D = project(dom,range(0,n));
-        BoxDomainType V = project(dom,range(n,p));
-        UpperBoxType BV = product(B,UpperBoxType(V));
+    virtual UpperBoxType _refinement(BoxDomainType D, BoxDomainType V, UpperBoxType BV, UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
         UpperBoxType B_end = D + IntervalDomainType(0,h)*apply(f,BV);
         UpperBoxType BV_end = product(B_end,UpperBoxType(V));
         return D + IntervalDomainType(0,h)/2*(apply(f,BV)+apply(f,BV_end));
     }
-
+  public:
     virtual ~HeunFlowBoundsMethod() = default;
 };
+
+class FlowBoundsMethodFactory {
+public:
+    static FlowBoundsMethod create(FlowBoundsMethodKind kind) {
+        switch(kind) {
+        case FlowBoundsMethodKind::EULER : return FlowBoundsMethod(SharedPointer<FlowBoundsMethodInterface>(new EulerFlowBoundsMethod()));
+        case FlowBoundsMethodKind::HEUN : return FlowBoundsMethod(SharedPointer<FlowBoundsMethodInterface>(new HeunFlowBoundsMethod()));
+        default:
+            ARIADNE_FAIL_MSG("Unexpected flow bounds method kind "<<kind<<"\n");
+        }
+    }
+};
+
+
+
 
 
 Pair<PositiveFloatDPValue,UpperBoxType> InclusionIntegrator::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
 
     PositiveFloatDPValue h=cast_exact(hsug);
 
-    EulerFlowBoundsMethod is;
+    FlowBoundsMethod fbm = FlowBoundsMethodFactory::create(FlowBoundsMethodKind::HEUN);
 
-    UpperBoxType B = is.initial(f,dom,h);
+    UpperBoxType B = fbm.initial(f,dom,h);
 
-    while(not refines(is.refinement(B,f,dom,h),B)) {
+    while(not refines(fbm.refinement(B,f,dom,h),B)) {
         h=hlf(h);
     }
 
     for(Nat i=0; i<4; ++i) {
-        B = is.refinement(B,f,dom,h);
+        B = fbm.refinement(B,f,dom,h);
     }
 
     return std::make_pair(h,B);

--- a/source/dynamics/differential_inclusion.hpp
+++ b/source/dynamics/differential_inclusion.hpp
@@ -102,6 +102,7 @@ template<class F> PositiveBounds<F> dexp(Bounds<F> const& x) {
     return PositiveBounds<F>(dexp(x.lower()),dexp(x.upper()));
 }
 
+
 class DifferentialInclusion {
 private:
     DottedRealAssignments _dynamics;

--- a/source/dynamics/differential_inclusion.hpp
+++ b/source/dynamics/differential_inclusion.hpp
@@ -393,7 +393,7 @@ public:
 class InclusionIntegratorInterface {
   public:
     virtual List<ValidatedVectorFunctionModelType> flow(DifferentialInclusionIVP const& di_ivp, Real T) = 0;
-    virtual Pair<ExactTimeStepType,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, ApproximateTimeStepType hsug) const = 0;
+    virtual Pair<ExactTimeStepType,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, ApproximateTimeStepType hsug) const = 0;
     virtual ValidatedVectorFunctionModelType reach(DifferentialInclusion const& di, BoxDomainType D, ValidatedVectorFunctionModelType evolve_function, UpperBoxType B, PositiveFloatDPValue t, PositiveFloatDPValue h) const = 0;
 };
 
@@ -416,7 +416,7 @@ class InclusionIntegrator : public virtual InclusionIntegratorInterface, public 
 
     virtual List<ValidatedVectorFunctionModelType> flow(DifferentialInclusionIVP const& di_ivp, Real T) override;
 
-    virtual Pair<ExactTimeStepType,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType V, BoxDomainType D, ApproximateTimeStepType hsug) const override;
+    virtual Pair<ExactTimeStepType,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, ApproximateTimeStepType hsug) const override;
     virtual ValidatedVectorFunctionModelType reach(DifferentialInclusion const& di, BoxDomainType D, ValidatedVectorFunctionModelType evolve_function, UpperBoxType B, PositiveFloatDPValue t, PositiveFloatDPValue h) const override;
   private:
     ValidatedVectorFunctionModelType compute_flow_function(ValidatedVectorFunction const& dyn, BoxDomainType const& domain, UpperBoxType const& B) const;

--- a/source/geometry/box.hpp
+++ b/source/geometry/box.hpp
@@ -176,6 +176,7 @@ class Box
     static Box<I> _product(const Box<I>& bx1, const I& ivl2);
 
     static Box<I> _project(const Box<I>& bx, const Array<SizeType>& rng);
+    static Box<I> _project(const Box<I>& bx, const Range& rng);
 };
 
 template<class I> inline OutputStream& operator<<(OutputStream& os, const Box<I>& bx) {
@@ -214,6 +215,7 @@ UpperBoxType image(UpperBoxType bx, ValidatedVectorFunction const& f);
 //! \relates Box \brief Project onto the variables \a rng.
 template<class I> inline Box<I> project(const Box<I> & bx, Array<SizeType> const& rng) { return Box<I>::_project(bx,rng); }
 
+template<class I> inline Box<I> project(const Box<I> & bx, Range const& rng) { return Box<I>::_project(bx,rng); }
 
 template<class I> auto midpoint(const Box<I>& bx) -> typename Box<I>::MidpointType {
     return bx.midpoint();

--- a/source/geometry/box.tpl.hpp
+++ b/source/geometry/box.tpl.hpp
@@ -183,6 +183,15 @@ template<class I> Box<I> Box<I>::_project(const Box<I>& bx, const Array<SizeType
     return std::move(res);
 }
 
+template<class I> Box<I> Box<I>::_project(const Box<I>& bx, const Range& rng)
+{
+    Box<I> res(rng.size());
+    for(SizeType i=0; i!=rng.size(); ++i) {
+        res[i]=bx[rng[i]];
+    }
+    return std::move(res);
+}
+
 template<class I> Box<I> Box<I>::_product(const Box<I>& bx1, const Box<I>& bx2)
 {
     Box<I> r(bx1.size()+bx2.size());

--- a/source/solvers/CMakeLists.txt
+++ b/source/solvers/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ariadne-solvers OBJECT
     solver.cpp
     integrator.cpp
+    bounder.cpp
     constraint_solver.cpp
     simplex_algorithm.cpp
     linear_programming.cpp

--- a/source/solvers/bounder.cpp
+++ b/source/solvers/bounder.cpp
@@ -123,15 +123,4 @@ UpperBoxType RungeKutta4Bounder::formula(BoxDomainType D, BoxDomainType V, Valid
     return (k1+2*k2+2*k3+k4)/6;
 }
 
-BounderHandler BounderFactory::create(Bounder method) {
-    switch(method) {
-    case Bounder::EULER : return BounderHandler(SharedPointer<BounderInterface>(new EulerBounder()));
-    case Bounder::HEUN : return BounderHandler(SharedPointer<BounderInterface>(new HeunBounder()));
-    case Bounder::RALSTON : return BounderHandler(SharedPointer<BounderInterface>(new RalstonBounder()));
-    case Bounder::RUNGEKUTTA4 : return BounderHandler(SharedPointer<BounderInterface>(new RungeKutta4Bounder()));
-    default:
-        ARIADNE_FAIL_MSG("Unexpected flow bounds method "<<method<<"\n");
-    }
-}
-
 } // namespace Ariadne;

--- a/source/solvers/bounder.cpp
+++ b/source/solvers/bounder.cpp
@@ -23,6 +23,8 @@
  */
 
 #include "bounder.hpp"
+#include "../function/formula.hpp"
+#include "../function/taylor_model.hpp"
 
 namespace Ariadne {
 

--- a/source/solvers/bounder.cpp
+++ b/source/solvers/bounder.cpp
@@ -26,7 +26,7 @@
 
 namespace Ariadne {
 
-Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
+Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::compute(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
     const PositiveFloatDPValue INITIAL_STARTING_WIDENING=cast_positive(2.0_exact);
     const PositiveFloatDPValue INITIAL_REFINING_WIDENING=cast_positive(1.125_exact);
     const PositiveFloatDPValue LIPSCHITZ_TOLERANCE=cast_positive(0.5_exact);

--- a/source/solvers/bounder.cpp
+++ b/source/solvers/bounder.cpp
@@ -29,7 +29,6 @@ namespace Ariadne {
 Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
     const PositiveFloatDPValue INITIAL_STARTING_WIDENING=cast_positive(2.0_exact);
     const PositiveFloatDPValue INITIAL_REFINING_WIDENING=cast_positive(1.125_exact);
-    const PositiveFloatDPValue NO_WIDENING=cast_positive(1.0_exact);
     const PositiveFloatDPValue LIPSCHITZ_TOLERANCE=cast_positive(0.5_exact);
     const Nat EXPANSION_STEPS=4;
     const Nat REFINEMENT_STEPS=4;
@@ -41,11 +40,12 @@ Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::flow_bounds(ValidatedVector
     h=cast_positive(min(hlip,h));
 
     UpperBoxType B;
+    UpperBoxType V(project(dom,range(f.result_size(),f.argument_size())));
     Bool success=false;
     while(!success) {
-        B=this->_initial(f,dom,h,INITIAL_STARTING_WIDENING);
+        B=this->_initial(dom,f,UpperBoxType(dom),h,INITIAL_STARTING_WIDENING);
         for(Nat i=0; i<EXPANSION_STEPS; ++i) {
-            UpperBoxType Br=this->_refinement(B,f,dom,h,NO_WIDENING);
+            UpperBoxType Br=this->_refinement(dom,f,B,h);
             if(not definitely(is_bounded(Br))) {
                 success=false;
                 break;
@@ -54,7 +54,8 @@ Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::flow_bounds(ValidatedVector
                 success=true;
                 break;
             } else {
-                B=this->_refinement(B,f,dom,h,INITIAL_REFINING_WIDENING);
+                UpperBoxType BV=product(B,V);
+                B=this->_initial(dom,f,BV,h,INITIAL_REFINING_WIDENING);
             }
         }
         if(!success) {
@@ -63,33 +64,33 @@ Pair<PositiveFloatDPValue,UpperBoxType> BounderBase::flow_bounds(ValidatedVector
     }
 
     for(Nat i=0; i<REFINEMENT_STEPS; ++i) {
-        B = this->_refinement(B,f,dom,h,NO_WIDENING);
+        B = this->_refinement(dom,f,B,h);
     }
 
     return std::make_pair(h,B);
 }
 
-UpperBoxType BounderBase::_initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const {
+UpperBoxType BounderBase::_initial(BoxDomainType dom, ValidatedVectorFunction f, UpperBoxType arg, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const {
     const PositiveFloatDPValue BOX_RADIUS_WIDENING=cast_positive(0.25_exact);
     SizeType n = f.result_size();
     SizeType p = f.argument_size();
     BoxDomainType D = project(dom,range(0,n));
     BoxDomainType V = project(dom,range(n,p));
     UpperBoxType wD = D + BOX_RADIUS_WIDENING*(D-D.midpoint());
-    return wD + FORMULA_WIDENING*formula(D,V,f,UpperBoxType(dom),h);
+    return wD + FORMULA_WIDENING*formula(D,V,f,arg,h);
 }
 
-UpperBoxType BounderBase::_refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const {
+UpperBoxType BounderBase::_refinement(BoxDomainType dom, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
     SizeType n = f.result_size();
     SizeType p = f.argument_size();
     BoxDomainType D = project(dom,range(0,n));
     BoxDomainType V = project(dom,range(n,p));
     UpperBoxType BV = product(B,UpperBoxType(V));
-    return D + FORMULA_WIDENING*formula(D,V,f,BV,h);
+    return D + formula(D,V,f,BV,h);
 }
 
-UpperBoxType EulerBounder::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
-    return IntervalDomainType(0,h)*apply(f,B);
+UpperBoxType EulerBounder::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType arg, PositiveFloatDPValue h) const {
+    return IntervalDomainType(0,h)*apply(f,arg);
 }
 
 UpperBoxType HeunBounder::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {

--- a/source/solvers/bounder.cpp
+++ b/source/solvers/bounder.cpp
@@ -1,0 +1,92 @@
+/***************************************************************************
+ *            bounder.cpp
+ *
+ *  Copyright  2018  Luca Geretti
+ *
+ ****************************************************************************/
+
+/*
+ *  This file is part of Ariadne.
+ *
+ *  Ariadne is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Ariadne is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Ariadne.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "bounder.hpp"
+
+namespace Ariadne {
+
+UpperBoxType FlowBoundsMethodHandlerBase::initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+    SizeType n = f.result_size();
+    SizeType p = f.argument_size();
+    BoxDomainType D = project(dom,range(0,n));
+    BoxDomainType V = project(dom,range(n,p));
+    UpperBoxType wD = D + (D-D.midpoint());
+    return wD + 2*formula(D,V,f,UpperBoxType(dom),h);
+}
+
+UpperBoxType FlowBoundsMethodHandlerBase::refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+    SizeType n = f.result_size();
+    SizeType p = f.argument_size();
+    BoxDomainType D = project(dom,range(0,n));
+    BoxDomainType V = project(dom,range(n,p));
+    UpperBoxType BV = product(B,UpperBoxType(V));
+    return D + formula(D,V,f,BV,h);
+}
+
+UpperBoxType EulerFlowBoundsHandler::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
+    return IntervalDomainType(0,h)*apply(f,B);
+}
+
+UpperBoxType HeunFlowBoundsHandler::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
+    UpperBoxType k1 = IntervalDomainType(0,h)*apply(f,B);
+    UpperBoxType B2 = D + k1;
+    UpperBoxType BV2 = product(B2,UpperBoxType(V));
+    UpperBoxType k2 = IntervalDomainType(0,h)*apply(f,BV2);
+    return (k1+k2)/2;
+}
+
+UpperBoxType RalstonFlowBoundsHandler::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
+    UpperBoxType k1 = IntervalDomainType(0,h)*apply(f,B);
+    UpperBoxType B2 = D+2*k1/3;
+    UpperBoxType BV2 = product(B2,UpperBoxType(V));
+    UpperBoxType k2 = IntervalDomainType(0,h)*apply(f,BV2);
+    return (k1+3*k2)/4;
+}
+
+UpperBoxType RungeKutta4FlowBoundsHandler::formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const {
+    UpperBoxType k1 = IntervalDomainType(0,h)*apply(f,B);
+    UpperBoxType B2 = D+k1/2;
+    UpperBoxType BV2 = product(B2,UpperBoxType(V));
+    UpperBoxType k2 = IntervalDomainType(0,h)*apply(f,BV2);
+    UpperBoxType B3 = D+k2/2;
+    UpperBoxType BV3 = product(B3,UpperBoxType(V));
+    UpperBoxType k3 = IntervalDomainType(0,h)*apply(f,BV3);
+    UpperBoxType B4 = D+k3;
+    UpperBoxType BV4 = product(B4,UpperBoxType(V));
+    UpperBoxType k4 = IntervalDomainType(0,h)*apply(f,BV4);
+    return (k1+2*k2+2*k3+k4)/6;
+}
+
+FlowBoundsMethodHandler FlowBoundsMethodHandlerFactory::create(FlowBoundsMethod method) {
+    switch(method) {
+    case FlowBoundsMethod::EULER : return FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface>(new EulerFlowBoundsHandler()));
+    case FlowBoundsMethod::HEUN : return FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface>(new HeunFlowBoundsHandler()));
+    case FlowBoundsMethod::RALSTON : return FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface>(new RalstonFlowBoundsHandler()));
+    case FlowBoundsMethod::RUNGEKUTTA4 : return FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface>(new RungeKutta4FlowBoundsHandler()));
+    default:
+        ARIADNE_FAIL_MSG("Unexpected flow bounds method "<<method<<"\n");
+    }
+}
+
+} // namespace Ariadne;

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -38,85 +38,85 @@
 
 namespace Ariadne {
 
-class FlowBoundsMethodHandlerFactory;
+class BounderFactory;
 
-class FlowBoundsMethodHandlerInterface {
+class BounderInterface {
   public:
-    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
+    virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const = 0;
 };
 
-class FlowBoundsMethodHandlerBase : public FlowBoundsMethodHandlerInterface {
+class BounderBase : public BounderInterface {
   public:
-    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+    Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const;
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const = 0;
-  public:
-    virtual ~FlowBoundsMethodHandlerBase() = default;
-};
-
-class EulerFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
-  protected:
-    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
-  public:
-    virtual ~EulerFlowBoundsHandler() = default;
-};
-
-class HeunFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
-  protected:
-    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
-  public:
-    virtual ~HeunFlowBoundsHandler() = default;
-};
-
-class RalstonFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
-  protected:
-    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
-  public:
-    virtual ~RalstonFlowBoundsHandler() = default;
-};
-
-class RungeKutta4FlowBoundsHandler : public FlowBoundsMethodHandlerBase {
-  protected:
-    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
-  public:
-    virtual ~RungeKutta4FlowBoundsHandler() = default;
-};
-
-class FlowBoundsMethodHandler : public FlowBoundsMethodHandlerInterface {
-    friend class FlowBoundsMethodHandlerFactory;
   private:
-    SharedPointer<FlowBoundsMethodHandlerInterface> _impl;
-    FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface> const& impl) : _impl(impl) { }
+    UpperBoxType _initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+    UpperBoxType _refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
   public:
-    FlowBoundsMethodHandler(FlowBoundsMethodHandler const& other) : _impl(other._impl) { }
-    FlowBoundsMethodHandler& operator=(FlowBoundsMethodHandler const& other) { _impl = other._impl; return *this; }
-
-    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        return _impl->initial(f,dom,h); }
-    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
-        return _impl->refinement(B,f,dom,h); }
-  public:
-    virtual ~FlowBoundsMethodHandler() = default;
+    virtual ~BounderBase() = default;
 };
 
-enum class FlowBoundsMethod : std::uint8_t { EULER, HEUN, RALSTON, RUNGEKUTTA4 };
+class EulerBounder : public BounderBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~EulerBounder() = default;
+};
 
-inline std::ostream& operator << (std::ostream& os, const FlowBoundsMethod& kind) {
+class HeunBounder : public BounderBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~HeunBounder() = default;
+};
+
+class RalstonBounder : public BounderBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~RalstonBounder() = default;
+};
+
+class RungeKutta4Bounder : public BounderBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~RungeKutta4Bounder() = default;
+};
+
+class BounderHandler : public BounderInterface {
+    friend class BounderFactory;
+  private:
+    SharedPointer<BounderInterface> _impl;
+    BounderHandler(SharedPointer<BounderInterface> const& impl) : _impl(impl) { }
+  public:
+    BounderHandler(BounderHandler const& other) : _impl(other._impl) { }
+    BounderHandler& operator=(BounderHandler const& other) { _impl = other._impl; return *this; }
+
+    virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
+        return _impl->flow_bounds(f,dom,hsug);
+    }
+  public:
+    virtual ~BounderHandler() = default;
+};
+
+enum class Bounder : std::uint8_t { EULER, HEUN, RALSTON, RUNGEKUTTA4 };
+
+inline std::ostream& operator << (std::ostream& os, const Bounder& kind) {
     switch (kind) {
-        case FlowBoundsMethod::EULER: os << "EULER"; break;
-        case FlowBoundsMethod::HEUN: os << "HEUN"; break;
-        case FlowBoundsMethod::RALSTON: os << "RALSTON"; break;
-        case FlowBoundsMethod::RUNGEKUTTA4: os << "RUNGEKUTTA4"; break;
-        default: ARIADNE_FAIL_MSG("Unhandled flow bounds method for output streaming\n");
+        case Bounder::EULER: os << "EULER"; break;
+        case Bounder::HEUN: os << "HEUN"; break;
+        case Bounder::RALSTON: os << "RALSTON"; break;
+        case Bounder::RUNGEKUTTA4: os << "RUNGEKUTTA4"; break;
+        default: ARIADNE_FAIL_MSG("Unhandled bounder method for output streaming\n");
     }
     return os;
 }
 
-class FlowBoundsMethodHandlerFactory {
+class BounderFactory {
 public:
-    static FlowBoundsMethodHandler create(FlowBoundsMethod method);
+    static BounderHandler create(Bounder method);
 };
 
 

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -51,8 +51,8 @@ class BounderBase : public BounderInterface {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const = 0;
   private:
-    UpperBoxType _initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
-    UpperBoxType _refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+    UpperBoxType _initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const;
+    UpperBoxType _refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const;
   public:
     virtual ~BounderBase() = default;
 };

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -83,22 +83,21 @@ class RungeKutta4Bounder : public BounderBase {
     virtual ~RungeKutta4Bounder() = default;
 };
 
-class BounderHandler : public BounderInterface {
+class BounderHandle : public BounderInterface {
     friend class BounderFactory;
   private:
     SharedPointer<BounderInterface> _impl;
-    BounderHandler(SharedPointer<BounderInterface> const& impl) : _impl(impl) { }
   public:
-    BounderHandler(BounderHandler const& other) : _impl(other._impl) { }
-    BounderHandler& operator=(BounderHandler const& other) { _impl = other._impl; return *this; }
+    BounderHandle(SharedPointer<BounderInterface> const& impl) : _impl(impl) { }
+    BounderHandle(BounderHandle const& other) : _impl(other._impl) { }
+    BounderHandle& operator=(BounderHandle const& other) { _impl = other._impl; return *this; }
 
     virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
         return _impl->flow_bounds(f,dom,hsug);
     }
   public:
-    virtual ~BounderHandler() = default;
+    virtual ~BounderHandle() = default;
 };
-
 
 } // namespace Ariadne
 

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -38,8 +38,6 @@
 
 namespace Ariadne {
 
-class BounderFactory;
-
 class BounderInterface {
   public:
     virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const = 0;
@@ -99,24 +97,6 @@ class BounderHandler : public BounderInterface {
     }
   public:
     virtual ~BounderHandler() = default;
-};
-
-enum class Bounder : std::uint8_t { EULER, HEUN, RALSTON, RUNGEKUTTA4 };
-
-inline std::ostream& operator << (std::ostream& os, const Bounder& kind) {
-    switch (kind) {
-        case Bounder::EULER: os << "EULER"; break;
-        case Bounder::HEUN: os << "HEUN"; break;
-        case Bounder::RALSTON: os << "RALSTON"; break;
-        case Bounder::RUNGEKUTTA4: os << "RUNGEKUTTA4"; break;
-        default: ARIADNE_FAIL_MSG("Unhandled bounder method for output streaming\n");
-    }
-    return os;
-}
-
-class BounderFactory {
-public:
-    static BounderHandler create(Bounder method);
 };
 
 

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -1,0 +1,125 @@
+/***************************************************************************
+ *            bounder.hpp
+ *
+ *  Copyright  2018  Luca Geretti
+ *
+ ****************************************************************************/
+
+/*
+ *  This file is part of Ariadne.
+ *
+ *  Ariadne is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Ariadne is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Ariadne.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*! \file bounder.hpp
+ *  \brief Classes for finding the bounds of the flow for differential equations.
+ */
+
+#ifndef ARIADNE_BOUNDER_HPP
+#define ARIADNE_BOUNDER_HPP
+
+#include "../utility/typedefs.hpp"
+#include "../utility/attribute.hpp"
+#include "../algebra/algebra.hpp"
+#include "../function/domain.hpp"
+#include "../function/function_model.hpp"
+#include "../output/logging.hpp"
+
+namespace Ariadne {
+
+class FlowBoundsMethodHandlerFactory;
+
+class FlowBoundsMethodHandlerInterface {
+  public:
+    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const = 0;
+};
+
+class FlowBoundsMethodHandlerBase : public FlowBoundsMethodHandlerInterface {
+  public:
+    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const;
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const = 0;
+  public:
+    virtual ~FlowBoundsMethodHandlerBase() = default;
+};
+
+class EulerFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~EulerFlowBoundsHandler() = default;
+};
+
+class HeunFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~HeunFlowBoundsHandler() = default;
+};
+
+class RalstonFlowBoundsHandler : public FlowBoundsMethodHandlerBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~RalstonFlowBoundsHandler() = default;
+};
+
+class RungeKutta4FlowBoundsHandler : public FlowBoundsMethodHandlerBase {
+  protected:
+    virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
+  public:
+    virtual ~RungeKutta4FlowBoundsHandler() = default;
+};
+
+class FlowBoundsMethodHandler : public FlowBoundsMethodHandlerInterface {
+    friend class FlowBoundsMethodHandlerFactory;
+  private:
+    SharedPointer<FlowBoundsMethodHandlerInterface> _impl;
+    FlowBoundsMethodHandler(SharedPointer<FlowBoundsMethodHandlerInterface> const& impl) : _impl(impl) { }
+  public:
+    FlowBoundsMethodHandler(FlowBoundsMethodHandler const& other) : _impl(other._impl) { }
+    FlowBoundsMethodHandler& operator=(FlowBoundsMethodHandler const& other) { _impl = other._impl; return *this; }
+
+    virtual UpperBoxType initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+        return _impl->initial(f,dom,h); }
+    virtual UpperBoxType refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h) const {
+        return _impl->refinement(B,f,dom,h); }
+  public:
+    virtual ~FlowBoundsMethodHandler() = default;
+};
+
+enum class FlowBoundsMethod : std::uint8_t { EULER, HEUN, RALSTON, RUNGEKUTTA4 };
+
+inline std::ostream& operator << (std::ostream& os, const FlowBoundsMethod& kind) {
+    switch (kind) {
+        case FlowBoundsMethod::EULER: os << "EULER"; break;
+        case FlowBoundsMethod::HEUN: os << "HEUN"; break;
+        case FlowBoundsMethod::RALSTON: os << "RALSTON"; break;
+        case FlowBoundsMethod::RUNGEKUTTA4: os << "RUNGEKUTTA4"; break;
+        default: ARIADNE_FAIL_MSG("Unhandled flow bounds method for output streaming\n");
+    }
+    return os;
+}
+
+class FlowBoundsMethodHandlerFactory {
+public:
+    static FlowBoundsMethodHandler create(FlowBoundsMethod method);
+};
+
+
+} // namespace Ariadne
+
+#endif /* ARIADNE_BOUNDER_HPP */

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -40,12 +40,16 @@ namespace Ariadne {
 
 class BounderInterface {
   public:
-    virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const = 0;
+    virtual Pair<PositiveFloatDPValue,UpperBoxType> compute(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const = 0;
+    virtual Void write(OutputStream& os) const = 0;
+
+    friend inline OutputStream& operator<<(OutputStream& os, const BounderInterface& bounder) {
+        bounder.write(os); return os; }
 };
 
-class BounderBase : public BounderInterface {
+class BounderBase : public BounderInterface, Loggable {
   public:
-    Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const;
+    virtual Pair<PositiveFloatDPValue,UpperBoxType> compute(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const;
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const = 0;
   private:
@@ -53,12 +57,14 @@ class BounderBase : public BounderInterface {
     UpperBoxType _refinement(BoxDomainType dom, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
     virtual ~BounderBase() = default;
+
 };
 
 class EulerBounder : public BounderBase {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
+    virtual Void write(OutputStream& os) const { os << "Euler"; }
     virtual ~EulerBounder() = default;
 };
 
@@ -66,6 +72,7 @@ class HeunBounder : public BounderBase {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
+    virtual Void write(OutputStream& os) const { os << "Heun"; }
     virtual ~HeunBounder() = default;
 };
 
@@ -73,6 +80,7 @@ class RalstonBounder : public BounderBase {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
+    virtual Void write(OutputStream& os) const { os << "Ralston"; }
     virtual ~RalstonBounder() = default;
 };
 
@@ -80,6 +88,7 @@ class RungeKutta4Bounder : public BounderBase {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
+    virtual Void write(OutputStream& os) const { os << "RungeKutta4"; }
     virtual ~RungeKutta4Bounder() = default;
 };
 
@@ -92,12 +101,16 @@ class BounderHandle : public BounderInterface {
     BounderHandle(BounderHandle const& other) : _impl(other._impl) { }
     BounderHandle& operator=(BounderHandle const& other) { _impl = other._impl; return *this; }
 
-    virtual Pair<PositiveFloatDPValue,UpperBoxType> flow_bounds(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
-        return _impl->flow_bounds(f,dom,hsug);
+    virtual Void write(OutputStream& os) const { _impl->write(os); }
+
+    virtual Pair<PositiveFloatDPValue,UpperBoxType> compute(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPApproximation hsug) const {
+        return _impl->compute(f,dom,hsug);
     }
   public:
     virtual ~BounderHandle() = default;
 };
+
+
 
 } // namespace Ariadne
 

--- a/source/solvers/bounder.hpp
+++ b/source/solvers/bounder.hpp
@@ -51,8 +51,8 @@ class BounderBase : public BounderInterface {
   protected:
     virtual UpperBoxType formula(BoxDomainType D, BoxDomainType V, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const = 0;
   private:
-    UpperBoxType _initial(ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const;
-    UpperBoxType _refinement(UpperBoxType B, ValidatedVectorFunction f, BoxDomainType dom, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const;
+    UpperBoxType _initial(BoxDomainType dom, ValidatedVectorFunction f, UpperBoxType arg, PositiveFloatDPValue h, PositiveFloatDPValue FORMULA_WIDENING) const;
+    UpperBoxType _refinement(BoxDomainType dom, ValidatedVectorFunction f, UpperBoxType B, PositiveFloatDPValue h) const;
   public:
     virtual ~BounderBase() = default;
 };

--- a/source/solvers/integrator.cpp
+++ b/source/solvers/integrator.cpp
@@ -94,7 +94,7 @@ IntegratorBase::function_factory() const
 
 Pair<FloatDPValue,UpperBoxType>
 IntegratorBase::flow_bounds(const ValidatedVectorFunction& vf, const ExactBoxType& domx, const RawFloatDP& hsug) const {
-    return EulerBounder().flow_bounds(vf,domx,PositiveFloatDPApproximation(hsug));
+    return EulerBounder().compute(vf,domx,PositiveFloatDPApproximation(hsug));
 }
 
 

--- a/source/solvers/integrator.cpp
+++ b/source/solvers/integrator.cpp
@@ -28,6 +28,7 @@
 #include <iomanip>
 
 #include "../solvers/integrator.hpp"
+#include "../solvers/bounder.hpp"
 
 #include "../output/logging.hpp"
 #include "../utility/container.hpp"
@@ -92,91 +93,8 @@ IntegratorBase::function_factory() const
 }
 
 Pair<FloatDPValue,UpperBoxType>
-IntegratorBase::flow_bounds(const ValidatedVectorFunction& vf, const ExactBoxType& domx, const RawFloatDP& hsug) const
-{
-    ARIADNE_LOG(3,"IntegratorBase::flow_bounds(ValidatedVectorFunction vf, ExactBoxType domx, FloatDP hmax)\n");
-    ARIADNE_ASSERT_MSG(vf.result_size()==domx.size(),"vector_field="<<vf<<", states="<<domx);
-    ARIADNE_ASSERT_MSG(vf.argument_size()==domx.size(),"vector_field="<<vf<<", states="<<domx);
-    ARIADNE_ASSERT(hsug>0);
-
-
-    // Set up constants of the method.
-    // TODO: Better estimates of constants
-    const FloatDPValue INITIAL_MULTIPLIER=2.0_exact;
-    const FloatDPValue MULTIPLIER=1.125_exact;
-    const FloatDPValue BOX_RADIUS_WIDENING=0.25_exact;
-    const Nat EXPANSION_STEPS=4;
-    const Nat REDUCTION_STEPS=8;
-    const Nat REFINEMENT_STEPS=4;
-
-    Vector<FloatDPBounds> const& dx=cast_singleton(domx);
-
-    Vector<UpperIntervalType> delta=(domx-midpoint(domx))*BOX_RADIUS_WIDENING;
-
-    // Compute the Lipschitz constant over the initial box
-    FloatDPUpperBound lip = norm(vf.jacobian(dx)).upper();
-    FloatDPValue hlip = cast_exact(this->_lipschitz_tolerance/lip);
-
-    FloatDPValue hmax(FloatDP(this->maximum_step_size()));
-    FloatDPValue h=cast_exact(hsug);
-    FloatDPValue hmin=h*(two^-REDUCTION_STEPS);
-    h=max(hmin,min(hmax,min(hlip,h)));
-    ARIADNE_LOG(4,"L="<<lip<<", hL="<<hlip<<", hmax="<<hmax<<"\n");
-
-    UpperBoxType bx,nbx;
-    Vector<UpperIntervalType> df;
-    UpperIntervalType ih(0,h);
-
-    Bool success=false;
-    while(!success) {
-        ARIADNE_ASSERT_MSG(h>=hmin," h="<<h<<", hmin="<<hmin);
-        bx=domx+INITIAL_MULTIPLIER*ih*vf.evaluate(dx)+delta;
-        for(Nat i=0; i!=EXPANSION_STEPS; ++i) {
-            df=apply(vf,bx);
-            nbx=domx+delta+ih*df;
-            ARIADNE_LOG(7,"h="<<h<<" nbx="<<nbx<<" bx="<<bx<<"\n");
-            if(not definitely(is_bounded(nbx))) {
-                success=false;
-                break;
-            } else if(refines(nbx,bx)) {
-                success=true;
-                break;
-            } else {
-                bx=domx+delta+MULTIPLIER*ih*df;
-            }
-        }
-        if(!success) {
-            h=hlf(h);
-            ih=UpperIntervalType(0,h);
-        }
-    }
-
-    ARIADNE_ASSERT(refines(nbx,bx));
-
-    Vector<UpperIntervalType> vfbx;
-    vfbx=apply(vf,bx);
-
-    for(Nat i=0; i!=REFINEMENT_STEPS; ++i) {
-        bx=nbx;
-        vfbx=apply(vf,bx);
-        nbx=domx+delta+ih*vfbx;
-        ARIADNE_ASSERT_MSG(refines(nbx,bx),std::setprecision(20)<<"refinement "<<i<<": "<<nbx<<" is not a inside of "<<bx);
-    }
-
-
-    // Check result of operation
-    // We use subset rather than inner subset here since the bound may touch
-    ARIADNE_ASSERT(refines(nbx,bx));
-
-    bx=nbx;
-
-
-    ARIADNE_ASSERT(refines(domx,bx));
-
-    ARIADNE_ASSERT_MSG(refines(domx+ih*apply(vf,bx),bx),
-        "d="<<dx<<"\nh="<<h<<"\nf(b)="<<apply(vf,bx)<<"\nd+hf(b)="<<(domx+ih*apply(vf,bx))<<"\nb="<<bx<<"\n");
-
-    return std::make_pair(FloatDPValue(h),bx);
+IntegratorBase::flow_bounds(const ValidatedVectorFunction& vf, const ExactBoxType& domx, const RawFloatDP& hsug) const {
+    return EulerBounder().flow_bounds(vf,domx,PositiveFloatDPApproximation(hsug));
 }
 
 

--- a/tests/dynamics/test_differential_inclusion.cpp
+++ b/tests/dynamics/test_differential_inclusion.cpp
@@ -137,6 +137,7 @@ void TestInclusionIntegrator::test() const {
 }
 
 int main() {
+
     TestInclusionIntegrator().test();
     return ARIADNE_TEST_FAILURES;
 }


### PR DESCRIPTION
I implemented the Bounder functionality (no enum class defined).

For now the Bounder class is used as the implementation of flow_bounds in both the Integrator and DifferentialInclusionIntegrator, so we have a unique implementation. 

As for the routine that calculates the bounds, I used IntegratorBase::flow_bounds as reference. While the "simplified" one from DifferentialInclusionIntegrator worked well on the DI examples, it wasn't robust enough for  test_hybrid_reachability_analyser: using it made the test require ~13 times the execution time as usual, i.e., the step size chosen was smaller than necessary.

Three notes on the pull request process:

1) I made python tests and tutorial skip on our CI, and I will add them as soon as they run properly. This means that, from now on, pull requests that merge onto working shall wait for Travis to give the green light (usually 40 minutes from the creation of the pull request). If the build fails, the pull request must be closed with no merge. This is quite convenient, since it allows to check remotely the result of merging without touching the origin repository itself.

2) Once deciding to merge using the GitHub interface directly, there are three possibilities: a simple merge upstream, a rebase+merge and a squash+merge. So I would suggest to use the rebase+merge strategy unless we want to make the merge point apparent.

3) If the assignee of the pull is me, and I only request a review from you, I think I should be able to receive the green from your review but still be able to execute the pull myself. Since this is new to me, confirmation from you @pietercollins is required. 