### PR TITLE
Improved CI configuration and output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,77 +6,74 @@ dist: trusty
 branches:
   only:
   - master
-  - pending
   - working
   - working-ci
 
 matrix:
   include:
 
-    - name: macOS 10.13 + AppleClang 10
+    - name: macOS 10.13 + AppleClang 10 + Python 3
       os: osx
       osx_image: xcode10
-      env: COMPILER=clang++
+      env: COMPILER=clang++ PYTHON=3
 
-    - name: macOS 10.12 + GCC 7
+    - name: macOS 10.13 + GCC 8 + Python 2
       os: osx
-      osx_image: xcode8.3
-      env: COMPILER=g++-7
+      osx_image: xcode10
+      env: COMPILER=g++-8 PYTHON=2
 
-    - name: Ubuntu 18.04 + Clang 5
+    - name: Ubuntu 18.04 + Clang 5 + Python 2
       os: linux
       services:
         - docker      
-      env: DOCKER=ubuntu:latest COMPILER=clang++-5.0
+      env: DOCKER=ubuntu:latest COMPILER=clang++-5.0 PYTHON=2
       
-    - name: Ubuntu 18.04 + GCC 8
+    - name: Ubuntu 18.04 + GCC 8 + Python 3
       os: linux
       services:
         - docker
-      env: DOCKER=ubuntu:latest COMPILER=g++-8  
+      env: DOCKER=ubuntu:latest COMPILER=g++-8 PYTHON=3
 
     - name: Coverage
       os: linux
       services:
         - docker
-      env: DOCKER=ubuntu:latest COMPILER=g++-7 COVERAGE=ON
+      env: DOCKER=ubuntu:latest COMPILER=g++-7 PYTHON=3 COVERAGE=ON
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi 
+  - if [[ "$PYTHON" == "3" ]]; then PYTHON_LIB='python3'; else PYTHON_LIB=python; fi 
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall --force oclint; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc@7 mpfr gmp gtk cairo; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc@8 mpfr gmp gtk cairo; fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      if [[ "$COMPILER" == "g++-7" ]]; then 
+      if [[ "$COMPILER" == "g++-8" ]]; then 
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        sudo -H python2 get-pip.py
-        sudo -H pip2 install coverage pytest --upgrade --ignore-installed six
-        PYTHON_VERSION=2
+        sudo -H python$PYTHON get-pip.py
+        sudo -H pip$PYTHON install coverage pytest --upgrade --ignore-installed six
       else
         sudo easy_install pip
-        sudo pip3 install --upgrade pip
-        sudo pip3 install coverage pytest
-        PYTHON_VERSION=3
+        sudo pip$PYTHON install --upgrade pip
+        sudo pip$PYTHON install coverage pytest
       fi
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      PYTHON_VERSION=3
       docker pull $DOCKER
       CONTAINER_ID=$(docker run --detach --tty --volume="$PWD":/ariadne --workdir=/ariadne $DOCKER)
       SH_PREFIX="docker exec --tty $CONTAINER_ID"
       $SH_PREFIX apt update
       $SH_PREFIX apt install -y cmake   
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $SH_PREFIX sh -c 'apt install -y '$COMPILER' python3-pip libpython3-dev libgtk2.0-dev libcairo2-dev libmpfr-dev libgmp-dev'; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $SH_PREFIX pip3 install coverage pytest; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then APT_INSTALL_STRING="apt install -y $COMPILER $PYTHON_LIB-pip lib$PYTHON_LIB-dev libgtk2.0-dev libcairo2-dev libmpfr-dev libgmp-dev"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then PIP_INSTALL_STRING="pip$PYTHON install coverage pytest"; fi   
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $SH_PREFIX sh -c "$APT_INSTALL_STRING"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $SH_PREFIX sh -c "$PIP_INSTALL_STRING"; fi
 
-script: 
-  - git submodule update --init --recursive
-  - CMAKE_ARGS="-DCMAKE_CXX_COMPILER=$COMPILER"
+script:
+  - CMAKE_ARGS="-DCMAKE_CXX_COMPILER=$COMPILER -DPYBIND11_PYTHON_VERSION=$PYTHON"
   - if [[ -n "$COVERAGE" ]]; then CMAKE_ARGS="$CMAKE_ARGS -DCOVERAGE=ON"; fi
   - if [[ -n "$COVERAGE" ]]; then CMAKE_BUILD_TYPE="Debug"; else CMAKE_BUILD_TYPE="Release"; fi 
-  - if [[ "$TRAVIS_BRANCH" =~ pending|master ]]; then CMAKE_ARGS="$CMAKE_ARGS -DWERROR=ON"; fi
+  - if [[ "$TRAVIS_BRANCH" == master ]]; then CMAKE_ARGS="$CMAKE_ARGS -DWERROR=ON"; fi
   - CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE"
   - $SH_PREFIX cmake . $CMAKE_ARGS
   - if [[ -n "$COVERAGE" ]]; then $SH_PREFIX make tests pyariadne; else $SH_PREFIX make; fi
@@ -89,7 +86,7 @@ script:
   - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/rigorous_numerics && cmake . '$CMAKE_ARGS; fi
   - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/rigorous_numerics && make'; fi  
   - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/rigorous_numerics && ./rigorous_numerics_tutorial > /dev/null'; fi
- # - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/python_interface && python'$PYTHON_VERSION' -m tutorial.py > /dev/null'; fi  
+ # - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/python_interface && python'$PYTHON' -m tutorial.py > /dev/null'; fi  
   
 after_success:
   - if [[ -n "$COVERAGE" ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ script:
   - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cp -Rf tutorials ~/tutorials'; fi
   - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/hybrid_evolution && cmake . '$CMAKE_ARGS; fi
   - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/hybrid_evolution && make'; fi  
-  - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/hybrid_evolution && ./hybrid_evolution_tutorial > /dev/null'; fi
+  - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/hybrid_evolution && ./hybrid_evolution_tutorial -v 0 > /dev/null'; fi
   - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/rigorous_numerics && cmake . '$CMAKE_ARGS; fi
   - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/rigorous_numerics && make'; fi  
   - if [[ -z "$COVERAGE" ]]; then $SH_PREFIX sh -c 'cd ~/tutorials/rigorous_numerics && ./rigorous_numerics_tutorial > /dev/null'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,15 +46,9 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc@8 mpfr gmp gtk cairo; fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      if [[ "$COMPILER" == "g++-8" ]]; then 
-        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        sudo -H python$PYTHON get-pip.py
-        sudo -H pip$PYTHON install coverage pytest --upgrade --ignore-installed six
-      else
-        sudo easy_install pip
-        sudo pip$PYTHON install --upgrade pip
-        sudo pip$PYTHON install coverage pytest
-      fi
+      sudo easy_install pip
+      sudo pip$PYTHON install --upgrade pip
+      sudo pip$PYTHON install coverage pytest
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/tutorials/hybrid_evolution/hybrid_evolution_tutorial.cpp
+++ b/tutorials/hybrid_evolution/hybrid_evolution_tutorial.cpp
@@ -227,7 +227,7 @@ inline Void compute_evolution(const CompositeHybridAutomaton& heating_system,con
     cout << "Plotting reach and evolve sets... " << flush;
     plot("tutorial-reach_evolve.png",Axes2d(0.0<=C<=1.0,14.0<=T<=23.0),
          Colour(0.0,0.5,1.0), reach, Colour(0.0,0.25,0.5), initial_enclosure, Colour(0.25,0.0,0.5), evolve);
-
+    cout << "    done." << endl;
 /*
     plot("tutorial-reach_evolve-off.png",Axes2d(0.0<=C<=1.0,14.0<=T<=23.0),
          Colour(0.0,0.5,1.0), reach[heating|off], Colour(0.25,0.0,0.5), evolve[heating|off]);
@@ -309,12 +309,18 @@ using namespace Ariadne::HeatingSystemTutorial;
 //! [main]
 Int main(Int argc, const char* argv[])
 {
+    Nat verbosity=1;
+    if(argc>1) {
+        if(std::strcmp(argv[1],"-v")==0) { if(argc>2) { verbosity=(Nat)std::atoi(argv[2]); } }
+    }
+
     // Create the system
     CompositeHybridAutomaton heating_system=create_heating_system();
     cout << heating_system << "\n";
 
     // Create the analyser classes
     HybridEvolverType evolver=create_evolver(heating_system);
+    evolver.verbosity = verbosity;
     cout << evolver << "\n";
 
     // Compute an approximate simulation of the system evolution


### PR DESCRIPTION
Moved the Travis configuration for macOS gcc to xcode10 + gcc@8. Also added ability to select the python version desired (2 or 3), and configured two builds to use Python 2 and the other two to use Python 3, for maximum variety. Minimized the output produced by running the hybrid evolution tutorial by silencing the evolver.