### PR TITLE
Added support for Fedora and openSUSE in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,30 +15,60 @@ matrix:
     - name: macOS 10.13 + AppleClang 10 + Python 3
       os: osx
       osx_image: xcode10
-      env: COMPILER=clang++ PYTHON=3
+      env: COMPILER=clang++ PYTHON=3 
 
-    - name: macOS 10.13 + GCC 8 + Python 2
+    - name: macOS 10.13 + GCC 8 + Python 2 [Debug]
       os: osx
       osx_image: xcode10
-      env: COMPILER=g++-8 PYTHON=2
+      env: COMPILER=g++-8 PYTHON=2 DEBUG=ON
 
-    - name: Ubuntu 18.04 + Clang 5 + Python 2
+    - name: Ubuntu 18.04 + Clang 6 + Python 3
       os: linux
       services:
         - docker      
-      env: DOCKER=ubuntu:latest COMPILER=clang++-5.0 PYTHON=2
+      env: DOCKER=ubuntu:bionic COMPILER=clang++-6.0 PYTHON=3
       
-    - name: Ubuntu 18.04 + GCC 8 + Python 3
+    - name: Ubuntu 18.04 + GCC 7 + Python 2 [Debug]
       os: linux
       services:
         - docker
-      env: DOCKER=ubuntu:latest COMPILER=g++-8 PYTHON=3
-
+      env: DOCKER=ubuntu:bionic COMPILER=g++-7 PYTHON=2 DEBUG=ON
+      
+    - name: Ubuntu 18.10 + GCC 8 + Python 3
+      os: linux
+      services:
+        - docker
+      env: DOCKER=ubuntu:cosmic COMPILER=g++-8 PYTHON=3
+      
+    - name: Fedora 28 + GCC 8 + Python 2
+      os: linux
+      services:
+        - docker
+      env: DOCKER=fedora:28 COMPILER=c++ PYTHON=2
+      
+    - name: Fedora 28 + Clang 6 + Python 3 [Debug]
+      os: linux
+      services:
+        - docker
+      env: DOCKER=fedora:28 COMPILER=clang++ PYTHON=3 DEBUG=ON
+      
+    - name: openSUSE Tumbleweed + GCC 8 + Python 3
+      os: linux
+      services:
+        - docker
+      env: DOCKER=opensuse/tumbleweed COMPILER=c++ PYTHON=3
+      
+    - name: openSUSE Tumbleweed + Clang 6 + Python 2 
+      os: linux
+      services:
+        - docker
+      env: DOCKER=opensuse/tumbleweed COMPILER=clang++ PYTHON=2
+           
     - name: Coverage
       os: linux
       services:
         - docker
-      env: DOCKER=ubuntu:latest COMPILER=g++-7 PYTHON=3 COVERAGE=ON
+      env: DOCKER=ubuntu:bionic COMPILER=g++-7 PYTHON=3 DEBUG=ON COVERAGE=ON
 
 before_install:
   - if [[ "$PYTHON" == "3" ]]; then PYTHON_LIB='python3'; else PYTHON_LIB=python; fi 
@@ -53,20 +83,24 @@ before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       docker pull $DOCKER
-      CONTAINER_ID=$(docker run --detach --tty --volume="$PWD":/ariadne --workdir=/ariadne $DOCKER)
+      CONTAINER_ID=$(docker run --detach --tty --volume="$PWD":/ariadne --workdir=/ariadne $DOCKER "/bin/bash")
       SH_PREFIX="docker exec --tty $CONTAINER_ID"
-      $SH_PREFIX apt update
-      $SH_PREFIX apt install -y cmake   
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then APT_INSTALL_STRING="apt install -y $COMPILER $PYTHON_LIB-pip lib$PYTHON_LIB-dev libgtk2.0-dev libcairo2-dev libmpfr-dev libgmp-dev"; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then PIP_INSTALL_STRING="pip$PYTHON install coverage pytest"; fi   
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $SH_PREFIX sh -c "$APT_INSTALL_STRING"; fi
+  - if [[ "$DOCKER" =~ ubuntu ]]; then $SH_PREFIX apt update; fi
+  - if [[ "$DOCKER" =~ ubuntu ]]; then PKG_INSTALL_STRING="apt install -y cmake $COMPILER $PYTHON_LIB-pip lib$PYTHON_LIB-dev libgtk2.0-dev libcairo2-dev libmpfr-dev libgmp-dev"; fi
+  - if [[ "$DOCKER" =~ opensuse|fedora ]]; then
+      if [[ "$COMPILER" == "c++" ]]; then COMPILER_PKG=gcc-c++; else COMPILER_PKG="clang gcc-c++"; fi
+    else COMPILER_PKG=$COMPILER; fi
+  - if [[ "$DOCKER" =~ fedora ]]; then PKG_INSTALL_STRING="dnf install -y make cmake $COMPILER_PKG $PYTHON_LIB-devel gtk2-devel mpfr-devel"; fi  
+  - if [[ "$DOCKER" =~ opensuse ]]; then PKG_INSTALL_STRING="zypper install -y cmake $COMPILER_PKG $PYTHON_LIB-devel python$PYTHON-pip gtk2-devel mpfr-devel"; fi  
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $SH_PREFIX sh -c "$PKG_INSTALL_STRING"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then PIP_INSTALL_STRING="pip$PYTHON install coverage pytest"; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then $SH_PREFIX sh -c "$PIP_INSTALL_STRING"; fi
 
 script:
   - CMAKE_ARGS="-DCMAKE_CXX_COMPILER=$COMPILER -DPYBIND11_PYTHON_VERSION=$PYTHON"
   - if [[ -n "$COVERAGE" ]]; then CMAKE_ARGS="$CMAKE_ARGS -DCOVERAGE=ON"; fi
-  - if [[ -n "$COVERAGE" ]]; then CMAKE_BUILD_TYPE="Debug"; else CMAKE_BUILD_TYPE="Release"; fi 
+  - if [[ -n "$DEBUG" ]]; then CMAKE_BUILD_TYPE="Debug"; else CMAKE_BUILD_TYPE="Release"; fi
   - if [[ "$TRAVIS_BRANCH" == master ]]; then CMAKE_ARGS="$CMAKE_ARGS -DWERROR=ON"; fi
   - CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE"
   - $SH_PREFIX cmake . $CMAKE_ARGS


### PR DESCRIPTION
This adds Fedora and openSUSE as CI jobs, each one for either gcc 8 or clang 6. It also introduces a flag for DEBUG compilation, used for Coverage and for other 3 jobs. This brings the total of jobs to 10, requiring two full passes since usually only 5 jobs can be taken simultaneosly. 

That's probably it for CI support on Travis. Will update the releases over time, but no more jobs will be introduced.