### PR TITLE
Reimplement Empty/Infinite Interval without Real(FloatDP), and add infinity conversions

### DIFF
--- a/source/geometry/interval.hpp
+++ b/source/geometry/interval.hpp
@@ -36,6 +36,7 @@
 #include "../numeric/logical.hpp"
 #include "../numeric/number.hpp"
 #include "../numeric/float.hpp"
+#include "../numeric/dyadic.hpp"
 #include "../numeric/arithmetic.hpp"
 
 #include "interval.decl.hpp"
@@ -331,6 +332,7 @@ Interval<FloatDPValue> approximate_domain(Interval<FloatDPUpperBound> const& ivl
 InputStream& operator>>(InputStream&, Interval<FloatDPValue>&);
 
 class EmptyInterval { };
+class EntireInterval { };
 
 } // namespace Ariadne
 

--- a/source/geometry/interval.inl.hpp
+++ b/source/geometry/interval.inl.hpp
@@ -31,9 +31,25 @@ template<class F> inline Value<F> make_split_point(Ball<F> const& bm) { return b
 
 
 template<class U> Interval<U>::Interval() : Interval(EmptyInterval()) { }
-template<class U> Interval<U>::Interval(EmptyInterval const&) : Interval(+infty,-infty) { }
+template<class U> Interval<U>::Interval(EmptyInterval const&) {
+    if constexpr(IsConstructibleGivenDefaultPrecision<U,Dyadic>::value) {
+        _l = L(Dyadic::inf(Sign::POSITIVE),L::RawType::get_default_precision());
+        _u = U(Dyadic::inf(Sign::NEGATIVE),U::RawType::get_default_precision());
+    } else {
+        _l = Dyadic::inf(Sign::POSITIVE);
+        _u = Dyadic::inf(Sign::NEGATIVE);
+    }
+}
 template<class U> Interval<U>::Interval(UnitInterval const&) : Interval(-1,+1) { }
-template<class U> Interval<U>::Interval(EntireInterval const&) : Interval(-infty,+infty) { }
+template<class U> Interval<U>::Interval(EntireInterval const&) {
+    if constexpr(IsConstructibleGivenDefaultPrecision<U,Dyadic>::value) {
+        _l = L(Dyadic::inf(Sign::NEGATIVE),L::RawType::get_default_precision());
+        _u = U(Dyadic::inf(Sign::POSITIVE),U::RawType::get_default_precision());
+    } else {
+        _l = Dyadic::inf(Sign::NEGATIVE);
+        _u = Dyadic::inf(Sign::POSITIVE);
+    }
+}
 template<class U> Interval<U>::Interval(LowerBoundType l, UpperBoundType u) : _l(l), _u(u) { }
 
 template<class U> Interval<U> Interval<U>::create_zero() const { return Interval<U>(0,0); }
@@ -47,7 +63,7 @@ template<class U> auto Interval<U>::width() const -> WidthType { return cast_pos
 
 template<class U> Interval<U> Interval<U>::empty_interval() { return Interval<U>(EmptyInterval()); }
 template<class U> Interval<U> Interval<U>::unit_interval() { return Interval<U>(-1,+1); }
-template<class U> Interval<U> Interval<U>::biinfinite_interval() { return Interval<U>(-infty,+infty); }
+template<class U> Interval<U> Interval<U>::biinfinite_interval() { return Interval<U>(EntireInterval()); }
 
 template<class U> auto Interval<U>::is_empty() const -> decltype(declval<L>()>declval<U>()) { return this->_l > this->_u; }
 template<class U> auto Interval<U>::is_bounded() const -> decltype(declval<U>()<declval<L>()) { return Ariadne::is_bounded(*this); }

--- a/source/numeric/dyadic.cpp
+++ b/source/numeric/dyadic.cpp
@@ -208,12 +208,12 @@ mpf_t const& Dyadic::get_mpf() const {
 }
 
 double Dyadic::get_d() const {
-    if (is_nan(*this)) {
-        return std::numeric_limits<double>::quiet_NaN();
-    } else if (is_inf(*this)) {
-        return (sgn(*this) == Sign::POSITIVE) ? std::numeric_limits<double>::infinity() : -std::numeric_limits<double>::infinity();
-    } else {
+    if (is_finite(*this))
         return mpf_get_d(this->_mpf);
+    else if (is_nan(*this)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    } else {
+        return (sgn(*this) == Sign::POSITIVE) ? std::numeric_limits<double>::infinity() : -std::numeric_limits<double>::infinity();
     }
 }
 

--- a/source/numeric/dyadic.cpp
+++ b/source/numeric/dyadic.cpp
@@ -208,7 +208,13 @@ mpf_t const& Dyadic::get_mpf() const {
 }
 
 double Dyadic::get_d() const {
-    return mpf_get_d(this->_mpf);
+    if (is_nan(*this)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    } else if (is_inf(*this)) {
+        return (sgn(*this) == Sign::POSITIVE) ? std::numeric_limits<double>::infinity() : -std::numeric_limits<double>::infinity();
+    } else {
+        return mpf_get_d(this->_mpf);
+    }
 }
 
 Dyadic operator+(TwoExp y) {

--- a/source/numeric/float-user.cpp
+++ b/source/numeric/float-user.cpp
@@ -127,7 +127,7 @@ template<class F> Value<F>::Value(Integer const& z, PR pr)
 template<class F> Value<F>::Value(Dyadic const& w, PR pr)
     : _v(w,pr)
 {
-    ARIADNE_ASSERT_MSG(Dyadic(this->_v)==w,"Dyadic number "<<w<<" cannot be converted exactly to a floating-point number with precision "<<pr<<"; nearest is "<<(*this));
+    ARIADNE_ASSERT_MSG(Dyadic(this->_v)==w || is_nan(w),"Dyadic number "<<w<<" cannot be converted exactly to a floating-point number with precision "<<pr<<"; nearest is "<<(*this));
 }
 
 template<class F> Value<F>::Value(Value<F> const& x, PR pr)

--- a/source/numeric/floatdp.cpp
+++ b/source/numeric/floatdp.cpp
@@ -625,7 +625,7 @@ double atan_rnd(double x) {
 FloatDP::FloatDP(Dyadic const& w, PrecisionType)
     : FloatDP(w.get_d())
 {
-    ARIADNE_ASSERT(Dyadic(*this)==w);
+    ARIADNE_ASSERT(Dyadic(*this)==w || is_nan(w));
 }
 
 FloatDP::FloatDP(double d, RoundingModeType rnd, PrecisionType)

--- a/source/numeric/floatdp.cpp
+++ b/source/numeric/floatdp.cpp
@@ -636,16 +636,18 @@ FloatDP::FloatDP(double d, RoundingModeType rnd, PrecisionType)
 FloatDP::FloatDP(Rational const& q, RoundingModeType rnd, PrecisionType)
     : FloatDP(q.get_d())
 {
-    RoundingModeType old_rnd=get_rounding_mode();
-    if(rnd==ROUND_UPWARD) {
-        set_rounding_upward();
-        while (Rational(dbl)<q) { dbl+=std::numeric_limits<double>::min(); }
-        set_rounding_mode(old_rnd);
-    }
-    if(rnd==ROUND_DOWNWARD) {
-        set_rounding_downward();
-        while (Rational(dbl)>q) { dbl-=std::numeric_limits<double>::min(); }
-        set_rounding_mode(old_rnd);
+   if (is_finite(q)) {
+        RoundingModeType old_rnd=get_rounding_mode();
+        if(rnd==ROUND_UPWARD) {
+            set_rounding_upward();
+            while (Rational(dbl)<q) { dbl+=std::numeric_limits<double>::min(); }
+            set_rounding_mode(old_rnd);
+        }
+        if(rnd==ROUND_DOWNWARD) {
+            set_rounding_downward();
+            while (Rational(dbl)>q) { dbl-=std::numeric_limits<double>::min(); }
+            set_rounding_mode(old_rnd);
+        }
     }
 }
 

--- a/source/numeric/floatmp.cpp
+++ b/source/numeric/floatmp.cpp
@@ -158,7 +158,15 @@ FloatMP& FloatMP::operator=(FloatMP&& x) {
 
 FloatMP::operator Dyadic() const {
     Dyadic res;
-    mpfr_get_f(res._mpf,this->_mpfr, MPFR_RNDN);
+    if (is_finite(*this)) {
+        mpfr_get_f(res._mpf,this->_mpfr, MPFR_RNDN);
+    } else if (is_nan(*this)) {
+        res._mpf[0]._mp_size=0;
+        res._mpf[0]._mp_exp=std::numeric_limits<mp_exp_t>::min();
+    } else {
+        res._mpf[0]._mp_size=0;
+        res._mpf[0]._mp_exp = (*this > 0) ? +1 : -1;
+    }
     return res;
 }
 

--- a/source/numeric/floatmp.cpp
+++ b/source/numeric/floatmp.cpp
@@ -83,20 +83,12 @@ FloatMP::FloatMP(Int32 n, MultiplePrecision pr) {
     mpfr_set_si(_mpfr,n.get_si(),get_rounding_mode());
 }
 
-FloatMP::FloatMP(Dyadic const& w, MultiplePrecision pr) {
-    mpfr_init2(_mpfr,pr);
-    if (is_finite(w)) {
-        mpfr_set_f(_mpfr,w.get_mpf(),get_rounding_mode());
-    } else if (is_nan(w)) {
-        mpfr_set_nan(_mpfr);
-    } else {
-        if (sgn(w) == Sign::POSITIVE) {
-            mpfr_set_inf(_mpfr,+1);
-        } else {
-            mpfr_set_inf(_mpfr,-1);
-        }
-    }
-    ARIADNE_ASSERT(Dyadic(*this)==w || is_nan(w));
+FloatMP::FloatMP(Rational const& q, MultiplePrecision pr) : FloatMP(q,get_rounding_mode(),pr) {
+
+}
+
+FloatMP::FloatMP(Dyadic const& w, MultiplePrecision pr) : FloatMP(w,get_rounding_mode(),pr) {
+
 }
 
 FloatMP::FloatMP(double d, RoundingModeType rnd, MultiplePrecision pr) {
@@ -116,12 +108,32 @@ FloatMP::FloatMP(Integer const& z, RoundingModeType rnd, MultiplePrecision pr) {
 
 FloatMP::FloatMP(Dyadic const& w, RoundingModeType rnd, MultiplePrecision pr) {
     mpfr_init2(_mpfr,pr);
-    mpfr_set_f(_mpfr,w.get_mpf(),rnd);
+    if (is_finite(w)) {
+        mpfr_set_f(_mpfr,w.get_mpf(),rnd);
+    } else if (is_nan(w)) {
+        mpfr_set_nan(_mpfr);
+    } else {
+        if (sgn(w) == Sign::POSITIVE) {
+            mpfr_set_inf(_mpfr,+1);
+        } else {
+            mpfr_set_inf(_mpfr,-1);
+        }
+    }
 }
 
 FloatMP::FloatMP(Rational const& q, RoundingModeType rnd, MultiplePrecision pr) {
     mpfr_init2(_mpfr,pr);
-    mpfr_set_q(_mpfr,q.get_mpq(),rnd);
+    if (is_finite(q)) {
+        mpfr_set_q(_mpfr,q.get_mpq(),rnd);
+    } else if (is_nan(q)) {
+        mpfr_set_nan(_mpfr);
+    } else {
+        if (sgn(q) == Sign::POSITIVE) {
+            mpfr_set_inf(_mpfr,+1);
+        } else {
+            mpfr_set_inf(_mpfr,-1);
+        }
+    }
 }
 
 FloatMP::FloatMP(FloatMP const& x, RoundingModeType rnd, MultiplePrecision pr) {

--- a/source/numeric/floatmp.cpp
+++ b/source/numeric/floatmp.cpp
@@ -83,10 +83,6 @@ FloatMP::FloatMP(Int32 n, MultiplePrecision pr) {
     mpfr_set_si(_mpfr,n.get_si(),get_rounding_mode());
 }
 
-FloatMP::FloatMP(Rational const& q, MultiplePrecision pr) : FloatMP(q,get_rounding_mode(),pr) {
-
-}
-
 FloatMP::FloatMP(Dyadic const& w, MultiplePrecision pr) : FloatMP(w,get_rounding_mode(),pr) {
 
 }

--- a/source/numeric/floatmp.cpp
+++ b/source/numeric/floatmp.cpp
@@ -63,7 +63,7 @@ FloatMP::FloatMP(double d) : FloatMP(d,get_default_precision()) {
 }
 
 FloatMP::FloatMP(double d, MultiplePrecision pr) : FloatMP(d,MPFR_RNDN,pr) {
-    ARIADNE_ASSERT(d==this->get_d());
+    ARIADNE_ASSERT(d==this->get_d() || isnan(d));
 }
 
 FloatMP::FloatMP(FloatDP const& x, MultiplePrecision pr) : FloatMP(x.get_d(),pr) {

--- a/source/numeric/floatmp.cpp
+++ b/source/numeric/floatmp.cpp
@@ -85,8 +85,18 @@ FloatMP::FloatMP(Int32 n, MultiplePrecision pr) {
 
 FloatMP::FloatMP(Dyadic const& w, MultiplePrecision pr) {
     mpfr_init2(_mpfr,pr);
-    mpfr_set_f(_mpfr,w.get_mpf(),get_rounding_mode());
-    ARIADNE_ASSERT(Dyadic(*this)==w);
+    if (is_finite(w)) {
+        mpfr_set_f(_mpfr,w.get_mpf(),get_rounding_mode());
+    } else if (is_nan(w)) {
+        mpfr_set_nan(_mpfr);
+    } else {
+        if (sgn(w) == Sign::POSITIVE) {
+            mpfr_set_inf(_mpfr,+1);
+        } else {
+            mpfr_set_inf(_mpfr,-1);
+        }
+    }
+    ARIADNE_ASSERT(Dyadic(*this)==w || is_nan(w));
 }
 
 FloatMP::FloatMP(double d, RoundingModeType rnd, MultiplePrecision pr) {

--- a/source/numeric/floatmp.cpp
+++ b/source/numeric/floatmp.cpp
@@ -63,7 +63,7 @@ FloatMP::FloatMP(double d) : FloatMP(d,get_default_precision()) {
 }
 
 FloatMP::FloatMP(double d, MultiplePrecision pr) : FloatMP(d,MPFR_RNDN,pr) {
-    ARIADNE_ASSERT(d==this->get_d() || isnan(d));
+    ARIADNE_ASSERT(d==this->get_d() || std::isnan(d));
 }
 
 FloatMP::FloatMP(FloatDP const& x, MultiplePrecision pr) : FloatMP(x.get_d(),pr) {

--- a/source/numeric/floatmp.hpp
+++ b/source/numeric/floatmp.hpp
@@ -117,6 +117,7 @@ class FloatMP {
     explicit FloatMP(PrecisionType);
     explicit FloatMP(double, PrecisionType);
     explicit FloatMP(FloatDP const&, PrecisionType);
+    explicit FloatMP(Rational const&, PrecisionType);
     explicit FloatMP(Dyadic const&, PrecisionType);
 
     FloatMP(const FloatMP&);

--- a/source/numeric/floatmp.hpp
+++ b/source/numeric/floatmp.hpp
@@ -117,7 +117,6 @@ class FloatMP {
     explicit FloatMP(PrecisionType);
     explicit FloatMP(double, PrecisionType);
     explicit FloatMP(FloatDP const&, PrecisionType);
-    explicit FloatMP(Rational const&, PrecisionType);
     explicit FloatMP(Dyadic const&, PrecisionType);
 
     FloatMP(const FloatMP&);

--- a/source/numeric/rational.cpp
+++ b/source/numeric/rational.cpp
@@ -140,8 +140,15 @@ Rational::Rational(Integer const& z) {
 }
 
 Rational::Rational(Dyadic const& f) {
-    mpq_init(_mpq);
-    mpq_set_f(_mpq,f._mpf);
+    mpq_init(this->_mpq);
+    Rational& q=*this;
+    if (is_finite(f)) {
+        mpq_set_f(q._mpq,f._mpf);
+    } else if (is_nan(f)) {
+        ExtensionOperations<Rational>::set_nan(q);
+    } else {
+        ExtensionOperations<Rational>::set_inf(q, f>0 ? Sign::POSITIVE : Sign::NEGATIVE);
+    }
 }
 
 Rational::Rational(Integer const& znum, Integer const& zden) {

--- a/source/numeric/rational.cpp
+++ b/source/numeric/rational.cpp
@@ -225,7 +225,13 @@ mpq_t const& Rational::get_mpq() const {
 }
 
 double Rational::get_d() const {
-    return mpq_get_d(this->_mpq);
+    if (is_finite(*this))
+        return mpq_get_d(this->_mpq);
+    else if (is_nan(*this)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    } else {
+        return (sgn(*this) == Sign::POSITIVE) ? std::numeric_limits<double>::infinity() : -std::numeric_limits<double>::infinity();
+    }
 }
 
 Integer Rational::get_num() const {

--- a/tests/numeric/test_dyadic.cpp
+++ b/tests/numeric/test_dyadic.cpp
@@ -164,6 +164,10 @@ void TestDyadic::test_infinity() {
 
     ARIADNE_TEST_BINARY_PREDICATE(operator<,Dyadic(double_max),Dyadic(double_inf));
 
+    ARIADNE_TEST_ASSERT(Dyadic::inf(Sign::POSITIVE).get_d()==std::numeric_limits<double>::infinity());
+    ARIADNE_TEST_ASSERT(Dyadic::inf(Sign::NEGATIVE).get_d()==-std::numeric_limits<double>::infinity());
+    ARIADNE_TEST_ASSERT(isnan(Dyadic::inf(Sign::ZERO).get_d()));
+
     ARIADNE_TEST_ASSERT(Dyadic(+double_inf)==Dyadic::inf(Sign(+1)));
     ARIADNE_TEST_ASSERT(Dyadic(-double_inf)==Dyadic::inf(Sign(-1)));
     ARIADNE_TEST_ASSERT(is_nan(Dyadic(double_nan)));

--- a/tests/numeric/test_float.cpp
+++ b/tests/numeric/test_float.cpp
@@ -371,6 +371,10 @@ TestFloat<PR>::test_limits()
     ARIADNE_TEST_EQUALS(Float(Dyadic::inf(Sign::POSITIVE),precision),FloatDP(pinf_d));
     ARIADNE_TEST_EQUALS(Float(Dyadic::inf(Sign::NEGATIVE),precision),FloatDP(ninf_d));
     ARIADNE_TEST_ASSERT(is_nan(Float(Dyadic::inf(Sign::ZERO),precision)));
+
+    ARIADNE_TEST_EQUALS(Float(Dyadic::inf(Sign::POSITIVE),upward,precision),FloatDP(pinf_d));
+    ARIADNE_TEST_EQUALS(Float(Dyadic::inf(Sign::NEGATIVE),upward,precision),FloatDP(ninf_d));
+    ARIADNE_TEST_ASSERT(is_nan(Float(Dyadic::inf(Sign::ZERO),upward,precision)));
 }
 
 

--- a/tests/numeric/test_float.cpp
+++ b/tests/numeric/test_float.cpp
@@ -34,6 +34,7 @@
 #include "numeric/rounding.hpp"
 #include "numeric/float.hpp"
 #include "numeric/numeric.hpp"
+#include "numeric/dyadic.hpp"
 
 #include "../test.hpp"
 
@@ -311,6 +312,9 @@ TestFloat<PR>::test_class()
 template<class PR> Void
 TestFloat<PR>::test_limits()
 {
+    double pinf_d = std::numeric_limits<double>::infinity();
+    double ninf_d = -std::numeric_limits<double>::infinity();
+    double nan_d = std::numeric_limits<double>::quiet_NaN();
 
     Float zero=Float(0,precision);
     Float one=Float(1,precision);
@@ -360,6 +364,13 @@ TestFloat<PR>::test_limits()
     ARIADNE_TEST_ASSERT(not(nan> one));
     ARIADNE_TEST_ASSERT(not(one> nan));
 
+    ARIADNE_TEST_EQUALS(Float(pinf_d).get_d(),pinf_d);
+    ARIADNE_TEST_EQUALS(Float(ninf_d).get_d(),ninf_d);
+    ARIADNE_TEST_ASSERT(is_nan(Float(nan_d)));
+
+    ARIADNE_TEST_EQUALS(Float(Dyadic::inf(Sign::POSITIVE),precision),FloatDP(pinf_d));
+    ARIADNE_TEST_EQUALS(Float(Dyadic::inf(Sign::NEGATIVE),precision),FloatDP(ninf_d));
+    ARIADNE_TEST_ASSERT(is_nan(Float(Dyadic::inf(Sign::ZERO),precision)));
 }
 
 

--- a/tests/numeric/test_rational.cpp
+++ b/tests/numeric/test_rational.cpp
@@ -135,6 +135,7 @@ void TestRational::test_comparisons() {
 
 void TestRational::test_infinity() {
     Rational qinf=Rational::inf();
+    Rational qninf=Rational::inf(Sign::NEGATIVE);
     Rational qnan=Rational::nan();
 
     ARIADNE_TEST_ASSERT(is_nan(Rational::nan()));
@@ -215,6 +216,9 @@ void TestRational::test_infinity() {
     ARIADNE_TEST_EQUALS(max(Rational::inf(Sign(-1)),Rational(-2)),Rational(-2));
     ARIADNE_TEST_EQUALS(max(Rational(-2),Rational::inf(Sign(+1))),Rational::inf(Sign(+1)));
 
+    ARIADNE_TEST_EQUALS(Rational(Dyadic::inf(Sign::POSITIVE)),qinf);
+    ARIADNE_TEST_EQUALS(Rational(Dyadic::inf(Sign::NEGATIVE)),qninf);
+    ARIADNE_TEST_ASSERT(is_nan(Rational(Dyadic::inf(Sign::ZERO))));
 }
 
 void TestRational::test_decimal() {


### PR DESCRIPTION
Empty and (bi)infinite intervals are now created from Dyadic using default precision. In order to make this work, several conversions were extended to account for infinities (+1,-1,0). Initially, this "broke" Approximation/LowerBound/UpperBound functionality for infinities, even if not apparent from the tests. The extension had to be introduced also for rounded conversions to make this work. Tests for all the originally failing conversions have been added in the appropriate files.

Due to the extensions involving conversion, it was not possible to reuse Extension code. If you @pietercollins feel that refactorings are really necessary, please add your own commits.

This pull request does not address using Dyadic for infinities globally, which may be done as a subsequent step.